### PR TITLE
Compare Terraform Show Outputs Before and After Model Serving Refactoring

### DIFF
--- a/cluster_us-central1.txt
+++ b/cluster_us-central1.txt
@@ -1,13 +1,16 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_cluster.model-serving:
-resource "google_container_cluster" "model-serving" {
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_cluster.cluster:
+resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr                        = "10.60.0.0/14"
     datapath_provider                        = null
     default_max_pods_per_node                = 110
-    deletion_protection                      = true
+    deletion_protection                      = false
     description                              = null
     effective_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     enable_autopilot                         = false
     enable_cilium_clusterwide_network_policy = false
@@ -21,7 +24,7 @@ resource "google_container_cluster" "model-serving" {
     endpoint                                 = "34.123.142.149"
     id                                       = "projects/voiceai-staging/locations/us-central1/clusters/model-serving"
     initial_node_count                       = 1
-    label_fingerprint                        = "a561eae6"
+    label_fingerprint                        = "47296234"
     location                                 = "us-central1"
     logging_service                          = "logging.googleapis.com/kubernetes"
     master_version                           = "1.28.15-gke.1020000"
@@ -40,14 +43,20 @@ resource "google_container_cluster" "model-serving" {
     project                                  = "voiceai-staging"
     remove_default_node_pool                 = true
     resource_labels                          = {
-        "cluster" = "model-serving"
+        "cluster"   = "model-serving"
+        "component" = "ai"
+        "feature"   = "external"
+        "team"      = "ai_eng"
     }
     self_link                                = "https://container.googleapis.com/v1/projects/voiceai-staging/locations/us-central1/clusters/model-serving"
     services_ipv4_cidr                       = "10.0.176.0/20"
     subnetwork                               = "projects/voiceai-staging/regions/us-central1/subnetworks/default"
     terraform_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     tpu_ipv4_cidr_block                      = null
 
@@ -62,7 +71,7 @@ resource "google_container_cluster" "model-serving" {
             disabled = true
         }
         http_load_balancing {
-            disabled = false
+            disabled = true
         }
         network_policy_config {
             disabled = true
@@ -201,11 +210,16 @@ resource "google_container_cluster" "model-serving" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -230,17 +244,17 @@ resource "google_container_cluster" "model-serving" {
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-c2d97c2f-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-22583924-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-53f6ff7e-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-390784a3-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-ba1fe6e3-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-a4060891-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-preem-c2d97c2f-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-preem-22583924-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-preem-53f6ff7e-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-spot-390784a3-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-spot-ba1fe6e3-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-spot-a4060891-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "c3-highcpu-22-preempt"
+        name                        = "c3-highcpu-22-spot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -252,15 +266,15 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 1
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 160
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -294,11 +308,16 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
 
@@ -321,27 +340,143 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-f115ac3a-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-8bf85748-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-7e29bc63-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-0aa27abf-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-8a532a5a-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-f3b81609-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-6a5c2942-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-f115ac3a-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-8bf85748-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-no-7e29bc63-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-t4-no-0aa27abf-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-24-spot-8a532a5a-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-24-spot-f3b81609-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-24-spot-6a5c2942-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-nonpreempt"
+        name                        = "g2-standard-24-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-central1-a",
+            "us-central1-b",
+            "us-central1-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.60.0.0/14"
+            pod_range            = "gke-model-serving-pods-9077f170"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-98317204-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-20dcbfdd-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-0228064d-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-4bc24623-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-98317204-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-20dcbfdd-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-nonsp-0228064d-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-nonsp-4bc24623-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -353,16 +488,16 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 100
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -403,7 +538,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -435,25 +575,25 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-1d3df81a-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-c2ba4109-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-952c9f5c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-c879b327-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-5522f085-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-e6d32d8b-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-preem-1d3df81a-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-preem-c2ba4109-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-preem-952c9f5c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-c879b327-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-nonsp-5522f085-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-e6d32d8b-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-standard-4-preempt"
+        name                        = "g2-standard-4-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -464,16 +604,16 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -514,7 +654,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -546,27 +691,27 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-e9504ce3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-8eed27a0-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-3c3165b3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-5970bb86-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-94554001-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-c6fd1e0d-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-6634f995-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-ef34555b-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-e9504ce3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-8eed27a0-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-3c3165b3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-5970bb86-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-spot-94554001-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-spot-c6fd1e0d-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-spot-6634f995-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-spot-ef34555b-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-preempt"
+        name                        = "n1-standard-4-spot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -579,15 +724,15 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 1
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 100
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -627,11 +772,16 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
 
@@ -660,25 +810,25 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-preempt-8858e2ea-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-preempt-8f88fc3f-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-preempt-02eab0ce-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-b2180517-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-2dd248c9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-5c0ad56e-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-preempt-8858e2ea-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-preempt-8f88fc3f-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-preempt-02eab0ce-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-b2180517-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-2dd248c9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-5c0ad56e-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-preempt"
+        name                        = "n2d-standard-4-spot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -690,129 +840,15 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 1
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 3
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.60.0.0/14"
-            pod_range            = "gke-model-serving-pods-9077f170"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-332a5f7b-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-e56aa049-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-58f1582e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n2d-preempt-4-dff58a6e-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n2d-preempt-4-332a5f7b-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n2d-preempt-4-e56aa049-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n2d-preempt-4-58f1582e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n2d-preempt-4-dff58a6e-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n2d-preempt-4"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-central1-a",
-            "us-central1-b",
-            "us-central1-c",
-            "us-central1-f",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 3
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -846,11 +882,16 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
 
@@ -873,25 +914,25 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-ce0b5cb3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-015517ee-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f6847575-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-d14c2118-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-0c473c45-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-48b81433-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-ce0b5cb3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-nonpr-015517ee-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f6847575-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-spot-d14c2118-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-spot-0c473c45-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-spot-48b81433-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-standard-4-nonpreempt"
+        name                        = "g2-standard-4-spot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -902,16 +943,16 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -952,10 +993,15 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
 
@@ -984,25 +1030,25 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-bf578ba6-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-nonpreempt-e94984fe-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-5d24ccbe-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-9e2024bf-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-0df2cd0b-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-95638d8d-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-nonpreempt-bf578ba6-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-nonpreempt-e94984fe-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-nonpreempt-5d24ccbe-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-24-nons-9e2024bf-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-24-nons-0df2cd0b-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-24-nons-95638d8d-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-nonpreempt"
+        name                        = "g2-standard-24-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -1013,16 +1059,16 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -1063,7 +1109,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -1095,25 +1146,25 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-d12e0481-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-3fd956e9-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-18924f65-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-1471850c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-09db72b6-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-216d47c6-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-d12e0481-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-3fd956e9-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-18924f65-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-1471850c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-09db72b6-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-216d47c6-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "c3-highcpu-22-nonpreempt"
+        name                        = "c3-highcpu-22-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -1124,16 +1175,16 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 160
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
@@ -1168,7 +1219,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -1194,8 +1250,8 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }

--- a/cluster_us-east1.txt
+++ b/cluster_us-east1.txt
@@ -1,31 +1,34 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_cluster.model-serving:
-resource "google_container_cluster" "model-serving" {
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_cluster.cluster:
+resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr                        = "10.28.0.0/14"
     datapath_provider                        = null
     default_max_pods_per_node                = 110
-    deletion_protection                      = true
+    deletion_protection                      = false
     description                              = null
     effective_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     enable_autopilot                         = false
     enable_cilium_clusterwide_network_policy = false
     enable_intranode_visibility              = false
     enable_kubernetes_alpha                  = false
-    enable_l4_ilb_subsetting                 = false
+    enable_l4_ilb_subsetting                 = true
     enable_legacy_abac                       = false
     enable_multi_networking                  = false
     enable_shielded_nodes                    = true
     enable_tpu                               = false
-    endpoint                                 = "34.138.0.8"
+    endpoint                                 = "34.73.220.190"
     id                                       = "projects/voiceai-staging/locations/us-east1/clusters/model-serving"
     initial_node_count                       = 1
-    label_fingerprint                        = "a561eae6"
+    label_fingerprint                        = "fb5908fc"
     location                                 = "us-east1"
     logging_service                          = "logging.googleapis.com/kubernetes"
     master_version                           = "1.28.15-gke.1020000"
-    min_master_version                       = "1.28.15-gke.1020000"
+    min_master_version                       = null
     monitoring_service                       = "monitoring.googleapis.com/kubernetes"
     name                                     = "model-serving"
     network                                  = "projects/voiceai-staging/global/networks/default"
@@ -40,14 +43,20 @@ resource "google_container_cluster" "model-serving" {
     project                                  = "voiceai-staging"
     remove_default_node_pool                 = true
     resource_labels                          = {
-        "cluster" = "model-serving"
+        "cluster"   = "model-serving"
+        "component" = "ai"
+        "feature"   = "external"
+        "team"      = "ai_eng"
     }
     self_link                                = "https://container.googleapis.com/v1/projects/voiceai-staging/locations/us-east1/clusters/model-serving"
     services_ipv4_cidr                       = "10.0.80.0/20"
     subnetwork                               = "projects/voiceai-staging/regions/us-east1/subnetworks/default"
     terraform_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     tpu_ipv4_cidr_block                      = null
 
@@ -57,6 +66,9 @@ resource "google_container_cluster" "model-serving" {
         }
         gcs_fuse_csi_driver_config {
             enabled = true
+        }
+        horizontal_pod_autoscaling {
+            disabled = true
         }
         http_load_balancing {
             disabled = false
@@ -80,7 +92,7 @@ resource "google_container_cluster" "model-serving" {
     control_plane_endpoints_config {
         dns_endpoint_config {
             allow_external_traffic = false
-            endpoint               = "gke-c9c5abccc90b4bdaa82f96a86ce588dfb151-397406432431.us-east1.gke.goog"
+            endpoint               = "gke-b539372ddc384a8b8b5a65f6616f51f82273-397406432431.us-east1.gke.goog"
         }
     }
 
@@ -111,9 +123,9 @@ resource "google_container_cluster" "model-serving" {
 
     ip_allocation_policy {
         cluster_ipv4_cidr_block       = "10.28.0.0/14"
-        cluster_secondary_range_name  = "gke-model-serving-pods-c9c5abcc"
+        cluster_secondary_range_name  = "gke-model-serving-pods-b539372d"
         services_ipv4_cidr_block      = "10.0.80.0/20"
-        services_secondary_range_name = "gke-model-serving-services-c9c5abcc"
+        services_secondary_range_name = "gke-model-serving-services-b539372d"
         stack_type                    = "IPV4"
 
         pod_cidr_overprovision_config {
@@ -124,7 +136,6 @@ resource "google_container_cluster" "model-serving" {
     logging_config {
         enable_components = [
             "SYSTEM_COMPONENTS",
-            "WORKLOADS",
         ]
     }
 
@@ -138,10 +149,20 @@ resource "google_container_cluster" "model-serving" {
     master_auth {
         client_certificate     = null
         client_key             = (sensitive value)
-        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRTnc0QU5Md0c2OVRCSUtWd0xyUVBEREFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSbU1qbG1PVFpoT0MxaU1ETmpMVFJoWVdNdE9EQmtNQzFtT1RJd05UbGlabVUwT0RJdwpJQmNOTWpVd01URXdNRGt5TmpRd1doZ1BNakExTlRBeE1ETXhNREkyTkRCYU1DOHhMVEFyQmdOVkJBTVRKR1l5Ck9XWTVObUU0TFdJd00yTXROR0ZoWXkwNE1HUXdMV1k1TWpBMU9XSm1aVFE0TWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQU5WNXFFcWxSbVpRUVc3V2V2QTdZSm9oWHFUY01RYVRxMGlCZzB1Kwp1bmttNGIrMHUzY1BSbWIwaEU3bzR1NW90SFB4NmdqU3ZuRGpWemZWRnpMWndiSGhRd1hMcnlnRkIvaU5aUTVIClVrL2pRak1Tc3NYdVE0TGZkbDRkY25GekZHUFJVK3RWWGpudTArbCtUMFhKZlIrQXA4ZkRSVnVoaG1JUGVqSS8KSWFxcHR4SStPMmN0c2tSaWJGd1pUYmYyOFNXaXlRU04rcHk1b3dDWXZYVUxTT0FNK0lxelZyditUZ2taWkFUOApCdTdsR0lCK1lKY1ZJMEtXaXpFZkJOZWkwYUs1TnQvcDUxZGc0eEQwQnQ5ZDVBb2xiY3BHTTRQbGxjRlJsaTZZCnpGcTJVTTFycEpOZnlFc0VmdWtzeGFuWitkbEx3OHYzK2hHR1M1SzFlUDB6RDlHazRCYkFjVkJiMUthR3pOSW8KS2wzcHlEdjhUUWFDZWMrQ2VTbVBCQzQ0Z2xiaEdPanFKSWVQTVgyczc0S2hQU0JBUlc5TnpzUmNKdWZJc3ZRRwpoWndzamJVOVRmVlo4MzlUOTFWMkRnMjdVMGFJWkVrdzMrYUlIZlQ0R3I0RU1nWVN6NU04blVJVE9ES2hrdmJCCnB2TmVpeENBL3NvRjF0d2JJVWRFRUtBSWNRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVoRVY3RUhvWjVBclErakNsUE4renpXcXQ1cjh3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFHaStiTlRMZ01maThVV2ZIQnVjZURGVDZvRDYrazNCbGhlQU1mN3UrNGsvCllvVklpbllTQklJdjkxMHBvQ0k3WjlIUE10OUp5ZU9hZmdSa3BEUUwxeFlKOFFLd1ZSQ1BlcllhNlgwNWluVW8KdWlZZjc0clFqbjduV0IrMkVycEJPRGZMYkZnVUwyZ0R3OEY0RTBhRlRnbEZBUmJIZ2dLK2JGVGdEN3IzR0NyNQowaVNCZE1zNitUN092L2x0NXhPVjd6UUtqeEkzaVZLMVpoWlI1a3hFVlNhOERLVTNtNGx1eGZnS0xZM0NrSENOCjR0cjhWS2xFL0FxdFVMWEk5TlRZN2lvSy82Rmh0RTNaWElsRTcyak1rODNFdFZyL2hlS2tkdjZycUhiOXpKeDIKZlFVTEVDNVhEMnUxLzVqbFBQTmdma3JQclF6V0MvUVJNY1ZNTEJrQjdJYkN5TjRJb0tXa0ZpLzArcHN3aTRCKwpWRW9CSFU5WklHaUIrWFpjYmdHbmpGZTRoYTNQQlk5Yk5SVTQ0eVRMM2NEQXUxVzRSUmI0S21PTFIwMVB1dnE5CmVYTTBOUHZmd1JnaVNqL0p3dVR4R1pkNW1wdmdkRHlPQ2xiaTMyV1pzaE4wa2M0a1NSVkFaYlVLM1NEQWJuNUIKNGRVUWw2b0ZmcXhjcmZ2VHAvRzBLdz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUplTy9vbXhOdlNCQzRpT0YraGJMWlV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa09ERXpNRFE0TUdZdFpXUmxZeTAwWm1ZNExXRTFOakV0WlRRME5tTXlPV0l4WXpZdwpNQ0FYRFRJMU1ERXdPREUzTWpNME5Wb1lEekl3TlRVd01UQXhNVGd5TXpRMVdqQXZNUzB3S3dZRFZRUURFeVE0Ck1UTXdORGd3WmkxbFpHVmpMVFJtWmpndFlUVTJNUzFsTkRRMll6STVZakZqTmpBd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDNGZwNWI2OGNUcldxbDgzZnc0YUFLbWRkWG95ZFY2dEd2WkpVUApCcUhqeVAzK0Z6QVZXYmpZUmhDTm0ybmxaZ245MWs4N2hpa3NsZW4wSVEwTnhuTUxsNDhndGd5MUU4Q29DSC9qCkRoajh3YVV2ZGFtU1FZM2d6RjN4a3ZBaUJDMTRqT2xNSHJXUy8wd0tZWmNmMDJKWDB1SWdkd1dEQlFwNlBmbmcKMlAwMEU5R0VGTHhzSDhMWGdEL1g0OEZaQ3hTN2VlY0MrdFJhZEV4cmRJdWs1MzAvU1RwSFVDOFhzOUxiSW90TApvMWZMVG8xVWdBUXJhOVNjVzRzdTV6VXBTdVdtUXJpWXIwWWpweE1uZitFY2NkN1dIUE9xWjFqbXJJWUFhZTl6CnRVcXNIdU1YOG5oL0llaWRwdlk1OFBWMjM0NGtpUXFZZ0w1cVg4TE9Ea3BjU2ZTb1Vqd3Yyc1Brc04wTWF6OE0KN0plSWFwMmxuOVV3MGduc3VBdnNpbGNrQUg0aTRQeVdhaHJDQXJaUUxEUUlEd1p3STg5bHprSlA4bkdLMXBwTwpaS0NZbktsOHZWejJYSnRXTExueVlTbW5sakNjSWhQaENhd0EzUlN0b0FyazRjc0N4blU1RzdrazJUeEw0ejNrClhXZ1k4cmpaWkV6ZjRobHFuc29jZFBoRm1KVUNBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGSVNZOWZXcGE5bnFZTVZKcFZMaFVETmZ4ZVBRTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQ01MNDhXc2VuU1ZaS3BCVmtzaklQdlEzMGJGWGpBVWNUcGtpMEtTM2F2CjZPcW5aOEJjeE5EVHlCb1pkMTJVWkIzd0xEODJ0UHUzR1VJSFNla082U1I3OVd0cnVueFUyMm05Zjg0S21NNlkKbWNlaDVPcTlDQ1IwTTlRWGFIL0ZUSzlwRHlPTmo1Z0F2dGc0Qi90eXF0a20xQ1JMQXo1WFJzS1o5WGl5bDVydwptbDJ1T1hJdXZFalRWTjBCWHVaZm5ueC95VVZBTkJCSmVicXNEbXFHQkRMNFR5YkdSSE4rcmZadHpQMlpGNEM0CkorSWZZNmJpMnQ0ZzE1MHMrbnplTXcvaW00NjlZeWpSQ2dzdldoTURqNVhnMVc4L1g2WWk2YndpQUZVSjBEeVYKaXBUL1p6anV4bnV4emdIR2o4OGYrSlpNeVZxb2RPc0V1ZnV6VVBIV0ZYMHpWY2N4VXhBZ1h5UFgrMTJUOVVNbQozRXV5dFlxY1lWREEwaXhEQ1lLYnlBd21BT0ZwdGh4TnNVbVFTM255bzVFYXlwdThuU1NLMGR1eVVVUURKY2NZCkgzOGl3T3dhaFI4UWdWV1JITkNDeWxTaUtMSFlScFRiN3hEUlB1Zm15TUxxTm1vcUtxNkF3SFVGMnZYWEpEbTEKRW5lTnA4RjZlSVhtTi9oMjBodk8xOWM9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
 
         client_certificate_config {
             issue_client_certificate = false
+        }
+    }
+
+    master_authorized_networks_config {
+        gcp_public_cidrs_access_enabled      = true
+        private_endpoint_enforcement_enabled = false
+
+        cidr_blocks {
+            cidr_block   = "0.0.0.0/0"
+            display_name = "All Addresses"
         }
     }
 
@@ -186,7 +207,7 @@ resource "google_container_cluster" "model-serving" {
         }
         local_ssd_count             = 0
         logging_variant             = "DEFAULT"
-        machine_type                = "g2-standard-24"
+        machine_type                = "g2-standard-4"
         metadata                    = {
             "disable-legacy-endpoints" = "true"
         }
@@ -196,7 +217,12 @@ resource "google_container_cluster" "model-serving" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -204,7 +230,7 @@ resource "google_container_cluster" "model-serving" {
         tags                        = []
 
         guest_accelerator {
-            count              = 2
+            count              = 1
             gpu_partition_size = null
             type               = "nvidia-l4"
         }
@@ -230,130 +256,19 @@ resource "google_container_cluster" "model-serving" {
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-nonpreempt-9f2f202e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-9b3677e8-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-nonpreempt-ff7daeb2-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-f4b9a5c9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-30939671-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-6fdea85e-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-nonpreempt-9f2f202e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-nonpreempt-9b3677e8-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-nonpreempt-ff7daeb2-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-nonsp-f4b9a5c9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-30939671-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-nonsp-6fdea85e-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-nonpreempt"
+        name                        = "g2-standard-4-nonspot"
         name_prefix                 = null
         node_count                  = 0
-        node_locations              = [
-            "us-east1-b",
-            "us-east1-c",
-            "us-east1-d",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-e5030560-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-2ef89e73-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-8c6c3a27-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-preem-e5030560-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-preem-2ef89e73-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-preem-8c6c3a27-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "c3-highcpu-22-preempt"
-        name_prefix                 = null
-        node_count                  = 1
         node_locations              = [
             "us-east1-b",
             "us-east1-c",
@@ -363,121 +278,22 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 1
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = []
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "c3-highcpu-22"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f9d6d7f4-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f9ee5ce9-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-3e9211fb-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f9d6d7f4-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f9ee5ce9-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-nonpr-3e9211fb-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east1-b",
-            "us-east1-c",
-            "us-east1-d",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
+            pod_range            = "gke-model-serving-pods-b539372d"
         }
 
         node_config {
@@ -511,7 +327,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -543,25 +364,25 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-d4ab158e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-46b2c4d7-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-414045d6-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-922a6185-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-b1e5105c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-6535846c-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-d4ab158e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-46b2c4d7-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-414045d6-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-922a6185-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-b1e5105c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-6535846c-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "c3-highcpu-22-nonpreempt"
+        name                        = "c3-highcpu-22-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -572,23 +393,23 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 160
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
+            pod_range            = "gke-model-serving-pods-b539372d"
         }
 
         node_config {
@@ -616,7 +437,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -642,25 +468,138 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-300524f8-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-6bfbadc5-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n2d-preempt-4-541a0949-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-f6892212-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-ea3bd747-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-n2d-preempt-4-300524f8-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n2d-preempt-4-6bfbadc5-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n2d-preempt-4-541a0949-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-spot-f6892212-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-spot-ea3bd747-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "n2d-preempt-4"
+        name                        = "n1-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east1-c",
+            "us-east1-d",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.28.0.0/14"
+            pod_range            = "gke-model-serving-pods-b539372d"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-9b8eabe7-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-3b1d3916-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-55c8da63-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-24-nons-9b8eabe7-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-24-nons-3b1d3916-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-24-nons-55c8da63-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-24-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -672,22 +611,587 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 3
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
+            pod_range            = "gke-model-serving-pods-b539372d"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-1628f2f5-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-fb1bbc63-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-082bbe7c-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-24-spot-1628f2f5-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-24-spot-fb1bbc63-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-24-spot-082bbe7c-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-24-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east1-b",
+            "us-east1-c",
+            "us-east1-d",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.28.0.0/14"
+            pod_range            = "gke-model-serving-pods-b539372d"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-6b0380f1-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-ecf07dba-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-nonsp-6b0380f1-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-nonsp-ecf07dba-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east1-c",
+            "us-east1-d",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.28.0.0/14"
+            pod_range            = "gke-model-serving-pods-b539372d"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-3af6e709-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-5e7f0878-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-ca455897-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-spot-3af6e709-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-spot-5e7f0878-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-spot-ca455897-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east1-b",
+            "us-east1-c",
+            "us-east1-d",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.28.0.0/14"
+            pod_range            = "gke-model-serving-pods-b539372d"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-1393ca57-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-00bfb5d4-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-a153c129-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-spot-1393ca57-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-spot-00bfb5d4-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-spot-a153c129-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "c3-highcpu-22-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east1-b",
+            "us-east1-c",
+            "us-east1-d",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 160
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.28.0.0/14"
+            pod_range            = "gke-model-serving-pods-b539372d"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = []
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "c3-highcpu-22"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-7ec35ccc-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-fbb66ae6-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-f6a4e9d9-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-7ec35ccc-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-fbb66ae6-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n2d-standard-4-spot-f6a4e9d9-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n2d-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east1-b",
+            "us-east1-c",
+            "us-east1-d",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 3
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.28.0.0/14"
+            pod_range            = "gke-model-serving-pods-b539372d"
         }
 
         node_config {
@@ -714,232 +1218,18 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-b1f880f8-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-0414ec03-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-fb1b9053-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-preem-b1f880f8-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-preem-0414ec03-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-preem-fb1b9053-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east1-b",
-            "us-east1-c",
-            "us-east1-d",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
             preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-236f3835-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-cea9f700-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-236f3835-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-cea9f700-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east1-c",
-            "us-east1-d",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
+            resource_labels             = {
                 "cluster"   = "model-serving"
                 "component" = "ai"
                 "feature"   = "external"
                 "team"      = "ai_eng"
             }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
 
             kubelet_config {
                 cpu_cfs_quota                          = false
@@ -960,227 +1250,8 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-b33ac3c1-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-7cee3a94-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-no-b33ac3c1-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-t4-no-7cee3a94-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east1-c",
-            "us-east1-d",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-preempt-6b952a3a-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-preempt-4067d6ac-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-preempt-fa632cd6-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-preempt-6b952a3a-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-preempt-4067d6ac-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-preempt-fa632cd6-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east1-b",
-            "us-east1-c",
-            "us-east1-d",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.28.0.0/14"
-            pod_range            = "gke-model-serving-pods-c9c5abcc"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
@@ -1194,8 +1265,8 @@ resource "google_container_cluster" "model-serving" {
 
     notification_config {
         pubsub {
-            enabled = false
-            topic   = null
+            enabled = true
+            topic   = "projects/voiceai-staging/topics/notifications-gke"
         }
     }
 
@@ -1204,9 +1275,9 @@ resource "google_container_cluster" "model-serving" {
         enable_private_nodes        = false
         master_ipv4_cidr_block      = null
         peering_name                = null
-        private_endpoint            = "10.142.0.62"
+        private_endpoint            = "10.142.0.82"
         private_endpoint_subnetwork = null
-        public_endpoint             = "34.138.0.8"
+        public_endpoint             = "34.73.220.190"
 
         master_global_access_config {
             enabled = false
@@ -1223,7 +1294,7 @@ resource "google_container_cluster" "model-serving" {
 
     security_posture_config {
         mode               = "BASIC"
-        vulnerability_mode = "VULNERABILITY_MODE_UNSPECIFIED"
+        vulnerability_mode = "VULNERABILITY_BASIC"
     }
 
     service_external_ips_config {

--- a/cluster_us-east4.txt
+++ b/cluster_us-east4.txt
@@ -1,31 +1,34 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_cluster.model-serving:
-resource "google_container_cluster" "model-serving" {
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_cluster.cluster:
+resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr                        = "10.44.0.0/14"
     datapath_provider                        = null
     default_max_pods_per_node                = 110
-    deletion_protection                      = true
+    deletion_protection                      = false
     description                              = null
     effective_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     enable_autopilot                         = false
     enable_cilium_clusterwide_network_policy = false
     enable_intranode_visibility              = false
     enable_kubernetes_alpha                  = false
-    enable_l4_ilb_subsetting                 = false
+    enable_l4_ilb_subsetting                 = true
     enable_legacy_abac                       = false
     enable_multi_networking                  = false
     enable_shielded_nodes                    = true
     enable_tpu                               = false
-    endpoint                                 = "35.245.56.166"
+    endpoint                                 = "35.194.82.26"
     id                                       = "projects/voiceai-staging/locations/us-east4/clusters/model-serving"
     initial_node_count                       = 1
-    label_fingerprint                        = "a561eae6"
+    label_fingerprint                        = "47296234"
     location                                 = "us-east4"
     logging_service                          = "logging.googleapis.com/kubernetes"
     master_version                           = "1.28.15-gke.1020000"
-    min_master_version                       = "1.28.15-gke.1020000"
+    min_master_version                       = null
     monitoring_service                       = "monitoring.googleapis.com/kubernetes"
     name                                     = "model-serving"
     network                                  = "projects/voiceai-staging/global/networks/default"
@@ -40,14 +43,20 @@ resource "google_container_cluster" "model-serving" {
     project                                  = "voiceai-staging"
     remove_default_node_pool                 = true
     resource_labels                          = {
-        "cluster" = "model-serving"
+        "cluster"   = "model-serving"
+        "component" = "ai"
+        "feature"   = "external"
+        "team"      = "ai_eng"
     }
     self_link                                = "https://container.googleapis.com/v1/projects/voiceai-staging/locations/us-east4/clusters/model-serving"
     services_ipv4_cidr                       = "10.0.144.0/20"
     subnetwork                               = "projects/voiceai-staging/regions/us-east4/subnetworks/default"
     terraform_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     tpu_ipv4_cidr_block                      = null
 
@@ -57,6 +66,9 @@ resource "google_container_cluster" "model-serving" {
         }
         gcs_fuse_csi_driver_config {
             enabled = true
+        }
+        horizontal_pod_autoscaling {
+            disabled = true
         }
         http_load_balancing {
             disabled = false
@@ -80,7 +92,7 @@ resource "google_container_cluster" "model-serving" {
     control_plane_endpoints_config {
         dns_endpoint_config {
             allow_external_traffic = false
-            endpoint               = "gke-4da5d9c495e24fe0bfaab7c429f2bf0b5ea3-397406432431.us-east4.gke.goog"
+            endpoint               = "gke-f79ef29fc0b54eb28ecb2cdc84c0592382fa-397406432431.us-east4.gke.goog"
         }
     }
 
@@ -111,9 +123,9 @@ resource "google_container_cluster" "model-serving" {
 
     ip_allocation_policy {
         cluster_ipv4_cidr_block       = "10.44.0.0/14"
-        cluster_secondary_range_name  = "gke-model-serving-pods-4da5d9c4"
+        cluster_secondary_range_name  = "gke-model-serving-pods-f79ef29f"
         services_ipv4_cidr_block      = "10.0.144.0/20"
-        services_secondary_range_name = "gke-model-serving-services-4da5d9c4"
+        services_secondary_range_name = "gke-model-serving-services-f79ef29f"
         stack_type                    = "IPV4"
 
         pod_cidr_overprovision_config {
@@ -124,7 +136,6 @@ resource "google_container_cluster" "model-serving" {
     logging_config {
         enable_components = [
             "SYSTEM_COMPONENTS",
-            "WORKLOADS",
         ]
     }
 
@@ -138,10 +149,20 @@ resource "google_container_cluster" "model-serving" {
     master_auth {
         client_certificate     = null
         client_key             = (sensitive value)
-        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQU1XUFBxZllRVzRQSFYzY2VGUHB1VlV3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa09ERTFNakUwWlRrdE1qSmtOQzAwTm1RMUxXSmlZMlF0WTJZME5UTmpabU5qTmpJMQpNQ0FYRFRJMU1ERXhNREE1TWpZME1Gb1lEekl3TlRVd01UQXpNVEF5TmpRd1dqQXZNUzB3S3dZRFZRUURFeVE0Ck1UVXlNVFJsT1MweU1tUTBMVFEyWkRVdFltSmpaQzFqWmpRMU0yTm1ZMk0yTWpVd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDeFFnM3lIRTVFcVhUNUE4VnlxZGhoclpIUENiV0ZFZ1RkUml4egprTTJuOFg1RlFLR1RHQjl5b3ZQRnFqSXZqNnFSMjgrbFlIL3l1bjZOMkJnMFhSSDc4SmtPTmdMNlFjdElOaUx1CllrYVhLc0xGTUtENThFSlVNZWJYTVloenFsSjFONkJ1WnFTcnVaZmI2cy9TU1FlT1NiN0RGeUI1eitEcHdEWnEKNW1xekkyYk1ocE4xZEhyYkluMXgwdlg0YjQ1RnlJa29xRVg0SHRHQ01qKzUwYktIYWEwUFhYRTd4eURIY1hoTApXYmlMeVdUcTRGV3JVVXdzQVQ1N0lDRE4xZXZCRGQyQ1Y5aHNhMTVqazVGVzdiekZ2NGx2dkdqQXk3Y3VRRk4zCjZjZVRReE1TVlJoRHpKaFg2Z0Yza0kxbnpFalpkaUJyQnIrTzJ3dUZxUGIveUQ0Vi9mL1VmTzRXVWtNbHYwMXYKVVRvUld3cWJJSjdOZmZwY2RsU09COTVlR3JuZ0pYYlkyVGxkOUEvc3QzT01Qc2Z6TU1JNThPUm0veFAybFhiOQp5eUYwVEJXT1d1TnIvbGJvQzlMc3daMnp2WWNQYldVUFAwQ29RRXVabU9pTDMwV1NmV1M0QWhYR2pTVzI0dUpICk94cS9FdXNMUTB2UUR5UXF5RmVxOTRmcmhkMENBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGTElZbGp6d0xRUWtHaDBtOG1haCtpcnZEOWpnTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQnkzTDdHaUQvcC9JckJzWHZvK3lMRXhEN0tRT1o5ZUQ1ZG9senNSVlBpCldneVNXbTNveTN2QmxkT1BPUTRSWkJmMzNXeGJRTldRbEhIcWE1OWwzb01OM3pPN0xpVXpYS1U0Wm0xcHJkM0UKU0Z4bldyOXdHd2tzVUZzaC95VjZucGVOcjRsWmp0ZDJyV1ZHRkg1MTdUSEZXaGFHRk9MSjFhTVBYd3oyaGtobgo0K1A0S09EMEczWmMvSGpxUThIdWRYRXQ1V0NoTkd2L2JwZGp5T2lzTFZTRHhXekRRTmJ6RmZ3V0xHZStUZ0lwCnhmSGJjck0zZWRrbklxcEJHN3F0Zy9kSGVCcE1ESVVhVHgyL3RReDlJWm9kZDZ3RFdENVF6QzNrUXVOWlljTTMKWmhuS2lOM05Id0QwdFQvdmhpaG5ydVNDVXBLRGQxbGF5RWtwMGJMSEFUc0lUMzBnNkE0Sko1eklPQmJ3b2hEWAplK0VYaVp3QmtLUHFiZGRwczFhcGcvN1BjV1NzRlMwdkdnSndHOEhXb1NTQ2NLcmdrbytiamtneTBFSU5LVW1sCmV6MnNrV2xiL1Y3MDJkOFhEYXVUMXJhWE9DblZWSnVkdGFENDRjV1RJZkl6MG03R3ppcXNYd0JCZHNXeXl0eEoKN2lrK1VyZ2Ryb0dDL2tJaW1IeWh3VzQ9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRS052TllzTTdlQXVlQmRNQ254TTdZekFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSak1qSTVOVEZtTUMweE5UQTVMVFE1TURFdE9HRTBPQzFoWVRFNFpUTm1aREprWkdJdwpJQmNOTWpVd01UQTRNVGN5TXpRMVdoZ1BNakExTlRBeE1ERXhPREl6TkRWYU1DOHhMVEFyQmdOVkJBTVRKR015Ck1qazFNV1l3TFRFMU1Ea3RORGt3TVMwNFlUUTRMV0ZoTVRobE0yWmtNbVJrWWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUs0OE53di9jRXpKejU2OURHVjVnS1VhTFJIMGQ2b2UycWNNeXpIeQpqeGlhNmF0SzdjZVFGKzgrVG1UcnZ3L2pWK0lscFVUL0MyOXllRHBtL1BKTHM4aEJWb21sU3RGRkMvMXU2ckszCk5XZllZR2xGYmZ5THltVWgzek44alFBWmFlZVJpVTZGMk9hYnM5Wm90c0VKMkRKQ1dXZkQzZ3ZscWxOZDU2SDAKR3JQSG1tNGNYK2pDT1A3SW1wdklSczlRU0JaVW5RbVJER3g3QzRFbjlCeXduZEtLZENaWUMyRE9SdXVBTTNuVQoxNERmbzJ3YlVwbVRlb1B2dmhTTGVvTHlWZ0hmTnFMbWgzSGRjRDBEaGdsaEl2SFZFd1RpK2ozZmZFa2ttczdFCkp4SjFEMTNCc3FpL0lWMk5GUXNtdXE2dDhNQ0VDVEg1RW1OQjVwTTRvWkcxbkUyOEczSTZuaCtLKzZ5SUNPak4KSVNwVll2dWdFYzhHUThhN0NGelB5ZitHUHlYY3ZuY3lpSXFLMVpuYjRqT1E5UHFiTFJRUFI3bjN6d1hLU1dSeQo2WXhadmxjMXRMRWRkZzUzdlIzd21LSEtveDNOY1ZXaVRpV0RJRGo3VXFmK0pDVlhhOE9RbEczMGRkcXhTa0dzCnE2UjZZTHMyZmRRSHBFTXZxQkRwZndkdmJRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVUwbCtES1RiOG5XRUpVaEZlWGUzaTkya240TzR3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFBL0dlNkJ2OVpVMlpXWThJbzd3cU92UEZUdldqaWFGN29pWEMzUVg5QXVVCmd0cStkRGJVZ0JBbUJxOG14OVRIcisxZWhuSXdWV1B5NHZESEp1bnBoVlZVZS92OHEwVW0xUkhXbUt1bVBOV1oKbjZKcExyZ2RxOTRLb05nU0dvakVzQm0xYmVONHFPTFZNdU9MYmhaZzg3Q0J2eFpBRGFicGRQemN0S1hyZ0dtTQpySzVocTIxQ3NWS1JMbTR3aXl0NVJZMVdpcGd2RjRoazd2cW9XbElyQW5mOWFsQWMvN1Iyb085TUR0SHZCd2RnClZVeUxnYUx6R2FNWkVMNnEwTGo1a08xaWxvQ2lOWlNReWJYS1ZjNDZ0dHdoWTFtbHBlRGlCMnFSdUdpOU9zV1EKc1YvYWk4RkRXY0VzaE1DU0VURW12ZlJ4eXQvZHBPa2pXRUFpOEsvblExQW9XcUUyTHFRczdTaEwxZVl5MjRoagptbFVCQkNtVWpNL3VDaE1SNGUwbzVvZ1RrSEw5TCs5VHJibFNqYlYrRDlndjM3SEl4NkxXOFZZNVA2VjBJM0VzCkJCajh2dlZSS3N2bWk0M0JNLytYV3RLSGM5WFF5R2EzRTZrZGZ0Z1N5ZDZpbk5aSUU0RU9ZMUJEU2Y1ZHphSUMKT0g1MWozMzQ3Tlg1VWlzcmF5VURsZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
 
         client_certificate_config {
             issue_client_certificate = false
+        }
+    }
+
+    master_authorized_networks_config {
+        gcp_public_cidrs_access_enabled      = true
+        private_endpoint_enforcement_enabled = false
+
+        cidr_blocks {
+            cidr_block   = "0.0.0.0/0"
+            display_name = "All Addresses"
         }
     }
 
@@ -169,13 +190,7 @@ resource "google_container_cluster" "model-serving" {
         boot_disk_kms_key           = null
         disk_size_gb                = 100
         disk_type                   = "pd-balanced"
-        effective_taints            = [
-            {
-                effect = "NO_SCHEDULE"
-                key    = "nvidia.com/gpu"
-                value  = "present"
-            },
-        ]
+        effective_taints            = []
         enable_confidential_storage = false
         image_type                  = "COS_CONTAINERD"
         labels                      = {
@@ -186,7 +201,7 @@ resource "google_container_cluster" "model-serving" {
         }
         local_ssd_count             = 0
         logging_variant             = "DEFAULT"
-        machine_type                = "g2-standard-24"
+        machine_type                = "n2d-standard-4"
         metadata                    = {
             "disable-legacy-endpoints" = "true"
         }
@@ -195,19 +210,18 @@ resource "google_container_cluster" "model-serving" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
-
-        guest_accelerator {
-            count              = 2
-            gpu_partition_size = null
-            type               = "nvidia-l4"
-        }
 
         kubelet_config {
             cpu_cfs_quota                          = false
@@ -230,551 +244,17 @@ resource "google_container_cluster" "model-serving" {
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-preempt-35daa318-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-preempt-4bf41f90-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-6399d1c2-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-c0ef80a3-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-93b09ad6-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-preempt-35daa318-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-preempt-4bf41f90-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-6399d1c2-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-c0ef80a3-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-93b09ad6-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-20699753-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-9d3ebe0b-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-20699753-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-9d3ebe0b-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-906c1492-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-821a68b3-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-preem-906c1492-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-preem-821a68b3-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-32dac3c4-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-befe4694-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-e2fd8374-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-32dac3c4-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-befe4694-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-t4-no-e2fd8374-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-b",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-9c3f6a2b-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-ad2ac853-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-8c66dcc3-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-9c3f6a2b-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-ad2ac853-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-8c66dcc3-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "c3-highcpu-22-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-b",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = []
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "c3-highcpu-22"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-a8b46c45-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-48a6a155-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-9b453bbc-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-a8b46c45-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-48a6a155-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-9b453bbc-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-preempt"
+        name                        = "n2d-standard-4-spot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -786,232 +266,22 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 1
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 3
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-f1470694-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-4304da83-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-3c766684-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-preem-f1470694-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-preem-4304da83-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-preem-3c766684-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "c3-highcpu-22-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-b",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = []
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "c3-highcpu-22"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-5b8d6051-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-f502307c-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-8568ee9c-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n2d-preempt-4-5b8d6051-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n2d-preempt-4-f502307c-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n2d-preempt-4-8568ee9c-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n2d-preempt-4"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-east4-a",
-            "us-east4-b",
-            "us-east4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 3
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
         }
 
         node_config {
@@ -1038,11 +308,16 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
 
@@ -1065,23 +340,23 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-308c993f-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-d0d0716c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-c9283ac0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-0deb3100-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-nonpreempt-308c993f-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-nonpreempt-d0d0716c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-24-nons-c9283ac0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-24-nons-0deb3100-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-nonpreempt"
+        name                        = "g2-standard-24-nonspot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -1091,23 +366,23 @@ resource "google_container_cluster" "model-serving" {
         version                     = "1.28.15-gke.1020000"
 
         autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
+            location_policy      = "ANY"
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.44.0.0/14"
-            pod_range            = "gke-model-serving-pods-4da5d9c4"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
         }
 
         node_config {
@@ -1141,7 +416,12 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -1173,8 +453,787 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-71faab4e-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-8da1c888-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-05ee716d-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-spot-71faab4e-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-spot-8da1c888-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-spot-05ee716d-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-b",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-08f5365e-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-72865fd4-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-spot-08f5365e-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-spot-72865fd4-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-7521d143-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-c91bbc54-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-24-spot-7521d143-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-24-spot-c91bbc54-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-24-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-9d8a5407-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-575aa9f6-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-9d8a5407-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-575aa9f6-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-d7a28962-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-e0f28ec0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-94803393-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-spot-d7a28962-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-spot-e0f28ec0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-spot-94803393-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "c3-highcpu-22-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-b",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 160
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = []
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "c3-highcpu-22"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-65993492-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-492647b4-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-dce47c20-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-65993492-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-492647b4-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-nonsp-dce47c20-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-b",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-b6815637-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-9c7f99c5-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-0c9c66d4-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-b6815637-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-9c7f99c5-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-0c9c66d4-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "c3-highcpu-22-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-east4-a",
+            "us-east4-b",
+            "us-east4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 160
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.44.0.0/14"
+            pod_range            = "gke-model-serving-pods-f79ef29f"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = []
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "c3-highcpu-22"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
@@ -1188,8 +1247,8 @@ resource "google_container_cluster" "model-serving" {
 
     notification_config {
         pubsub {
-            enabled = false
-            topic   = null
+            enabled = true
+            topic   = "projects/voiceai-staging/topics/notifications-gke"
         }
     }
 
@@ -1198,9 +1257,9 @@ resource "google_container_cluster" "model-serving" {
         enable_private_nodes        = false
         master_ipv4_cidr_block      = null
         peering_name                = null
-        private_endpoint            = "10.150.0.13"
+        private_endpoint            = "10.150.0.9"
         private_endpoint_subnetwork = null
-        public_endpoint             = "35.245.56.166"
+        public_endpoint             = "35.194.82.26"
 
         master_global_access_config {
             enabled = false
@@ -1217,7 +1276,7 @@ resource "google_container_cluster" "model-serving" {
 
     security_posture_config {
         mode               = "BASIC"
-        vulnerability_mode = "VULNERABILITY_MODE_UNSPECIFIED"
+        vulnerability_mode = "VULNERABILITY_BASIC"
     }
 
     service_external_ips_config {

--- a/cluster_us-west1.txt
+++ b/cluster_us-west1.txt
@@ -1,31 +1,34 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_cluster.model-serving:
-resource "google_container_cluster" "model-serving" {
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_cluster.cluster:
+resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr                        = "10.64.0.0/14"
     datapath_provider                        = null
     default_max_pods_per_node                = 110
-    deletion_protection                      = true
+    deletion_protection                      = false
     description                              = null
     effective_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     enable_autopilot                         = false
     enable_cilium_clusterwide_network_policy = false
     enable_intranode_visibility              = false
     enable_kubernetes_alpha                  = false
-    enable_l4_ilb_subsetting                 = false
+    enable_l4_ilb_subsetting                 = true
     enable_legacy_abac                       = false
     enable_multi_networking                  = false
     enable_shielded_nodes                    = true
     enable_tpu                               = false
-    endpoint                                 = "34.168.40.202"
+    endpoint                                 = "34.169.12.0"
     id                                       = "projects/voiceai-staging/locations/us-west1/clusters/model-serving"
     initial_node_count                       = 1
-    label_fingerprint                        = "a561eae6"
+    label_fingerprint                        = "ebe49969"
     location                                 = "us-west1"
     logging_service                          = "logging.googleapis.com/kubernetes"
     master_version                           = "1.28.15-gke.1020000"
-    min_master_version                       = "1.28.15-gke.1020000"
+    min_master_version                       = null
     monitoring_service                       = "monitoring.googleapis.com/kubernetes"
     name                                     = "model-serving"
     network                                  = "projects/voiceai-staging/global/networks/default"
@@ -40,14 +43,20 @@ resource "google_container_cluster" "model-serving" {
     project                                  = "voiceai-staging"
     remove_default_node_pool                 = true
     resource_labels                          = {
-        "cluster" = "model-serving"
+        "cluster"   = "model-serving"
+        "component" = "ai"
+        "feature"   = "external"
+        "team"      = "ai_eng"
     }
     self_link                                = "https://container.googleapis.com/v1/projects/voiceai-staging/locations/us-west1/clusters/model-serving"
     services_ipv4_cidr                       = "10.0.192.0/20"
     subnetwork                               = "projects/voiceai-staging/regions/us-west1/subnetworks/default"
     terraform_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     tpu_ipv4_cidr_block                      = null
 
@@ -57,6 +66,9 @@ resource "google_container_cluster" "model-serving" {
         }
         gcs_fuse_csi_driver_config {
             enabled = true
+        }
+        horizontal_pod_autoscaling {
+            disabled = true
         }
         http_load_balancing {
             disabled = false
@@ -80,7 +92,7 @@ resource "google_container_cluster" "model-serving" {
     control_plane_endpoints_config {
         dns_endpoint_config {
             allow_external_traffic = false
-            endpoint               = "gke-7aa05e65844a426c9501a174f2067c9ce73b-397406432431.us-west1.gke.goog"
+            endpoint               = "gke-a44f9cd86fb44080b92b39a2cc30d73d560b-397406432431.us-west1.gke.goog"
         }
     }
 
@@ -111,9 +123,9 @@ resource "google_container_cluster" "model-serving" {
 
     ip_allocation_policy {
         cluster_ipv4_cidr_block       = "10.64.0.0/14"
-        cluster_secondary_range_name  = "gke-model-serving-pods-7aa05e65"
+        cluster_secondary_range_name  = "gke-model-serving-pods-a44f9cd8"
         services_ipv4_cidr_block      = "10.0.192.0/20"
-        services_secondary_range_name = "gke-model-serving-services-7aa05e65"
+        services_secondary_range_name = "gke-model-serving-services-a44f9cd8"
         stack_type                    = "IPV4"
 
         pod_cidr_overprovision_config {
@@ -124,7 +136,6 @@ resource "google_container_cluster" "model-serving" {
     logging_config {
         enable_components = [
             "SYSTEM_COMPONENTS",
-            "WORKLOADS",
         ]
     }
 
@@ -138,10 +149,20 @@ resource "google_container_cluster" "model-serving" {
     master_auth {
         client_certificate     = null
         client_key             = (sensitive value)
-        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRTkFMV2VtUWtHU1RHYUVLejgzMWJuVEFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlSak1EUTJNV1ZoT0MweU5UZGxMVFF5TW1NdFlqQXdOQzFrWTJFeVpXUmlNR00zWkRRdwpJQmNOTWpVd01URXdNRGt5TmpReFdoZ1BNakExTlRBeE1ETXhNREkyTkRGYU1DOHhMVEFyQmdOVkJBTVRKR013Ck5EWXhaV0U0TFRJMU4yVXROREl5WXkxaU1EQTBMV1JqWVRKbFpHSXdZemRrTkRDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUt6NW5VWlMwZUd0c1BSaVhubU9nSlZBbU5QWmZpdElXeFV2cUIrQgoxbUYzOXFYWW0vOUEwYUtxb3pjbEQrUCtCb3NKMFVZNUtPTmtSMnFUVndrZzkzRHpRbCtoYlFTc09lTGFRS3JsCmVjMUZOM1pNbDRPZWNLWWRRWGEyaGpEU0NyNWtYYXNaZGdBZ2pxMlY3R005N2F0VDVUeW1zbkEvMFZrZjVPbTIKdnBvdWFkcEdEL0JyeFN2R3NSUzJCMWJ1T0pZOWYvRzBXRWUxWmhNWmhKSXBYZ0kzdlIrRzhWZFcxK1ZmMDg5ZwpieFhVdzI2ZHBITG9GNS82WFFoeDNVbmhsclBxK2cyUnRiekY1bjRyQk95elFlZVJwWWZHamh6SmxwdWhWZmVqCnNTN0FxaWorUWJENnd3cVJqWHhJOHNSanhUSytRZ0IwVmo2eUdIR2g3TVdTVjljdUNvNUhCM09EMjFldERZdEsKaXU3ZnhNNUo1ZGpxZWo3OWJEOHFsZmpzME14T2IwWlRmdEpCaWd1aEdBbllEM0xTdTVLa1ZoMDBLMXE1cFJXQQpiTkhja3RvWUptM0lYNkJDdUdOK0k5NFFiMlFIQmptWWVJZG55Qld2ZU1xeWlrbVc2RnFld01sdmY0K0RJL0VVCjRYR2JUUTFVWHlZTkJIYW93bHVFbzJrMGVRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVEVzFlS1dVSG92M3RlRi9QeHlhbk13bHdwazR3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFDT3VrY0tUNDJoSzk3c3lDSXVZaXlPY2pUNmVXNTVuZ2dpdzlXVmFqeit6CmxQZG04bmNCNXJ4ZVhYN3Z0R1c5b2x3QWNINHZwYlJHVXhsSGZwWWNnZ3N6Y01VZEdsMVZ2SExqYlNhc2JWZW0KOWM0YzRVLzk5VzAybnUyY2pIenl0ZG1lWE1UUUNTYTlydndZd25NTEJlUHkrc0NVS0luYi9lZVQxZW5Jc1dCLwowRVZucEJTK0FQMjdFZmFaaUhqQ21sMVh5U2Q1WE5XdUxmeTUrMytKSlZ0aVdDRlNUYmdHUnpjbVVyamQrREJVCmNnVjI1MHI4Q0hzZDNkNU5VOTJpVFFadnI2RklpU2M5eFp0VTdiZFFmNENySlFabWNLTGk1ejdpQnZGV1FWNEgKSkJQczFFZzR4dUtBVzRRU2pKTHhnYXNGN214cll3dFdMOFYrc2MrKzlXNHVDeWV0OExmcFVtdTZGV2xMOEtPTApkSGRpRWlIWVcyayt4S1lpMm5QeXNxbXYyMDBrTFFFalBLYTJBN2VoSWJzQVN5eVdzaGVQNkNzWkNnaXdIUHhECmxHRkFrM2I5VW1LUHpuMDc4WXgzeHcrRS82RlY1RHhmbE1QOVRkVnlZYVI1bFhFVzM0OFpDeFBlVUZuSDFhSTQKRHZjaG1xcU04YjFlQUk5MGFPT2R5QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQVBOWEt5MXo4TWVlb09oTGhzUy9WTVl3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa09ETmpaamd3WTJRdE1qazNZaTAwTW1ZMUxUZzFZVFV0T0RkbE9HVXhaalptWkRZegpNQ0FYRFRJMU1ERXdPREUzTWpNME5sb1lEekl3TlRVd01UQXhNVGd5TXpRMldqQXZNUzB3S3dZRFZRUURFeVE0Ck0yTm1PREJqWkMweU9UZGlMVFF5WmpVdE9EVmhOUzA0TjJVNFpURm1ObVprTmpNd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FDdzVpSDlWQktZYkVka2xPcVZJRlVlY1dPdVVqL2xtRC9ZRDFBMQpYbkJWN0djTE14WUFjeWxGcGE2aVZmTENDWmxaby9hMmI3VlFiM3J3Y3lCUG0yUzVvbVVJVDFvUnBmNnI2WnhsCldkenNPZ0xudWswOUZrZFFrK09EN3ZGTklTaW0rSmh6dzNJZVo2dDZYRGRuTkkzclBiSmdPU0lmaE4wSWJ2TTIKUHFFTG1lS0tWWmZzY2RpR3h0cmwvR2I5d2lPT1BWWndvaUdOUXpOUCtQMkFxZXdJTzNLc3ZvWG9SVnJVY0N6MAprZEF3czhPNitRa0JXaGRaRXNoQVphdHVPQmltdDFOLy9Henhzb3RYMFB4UmJFTFI4VjVZNWZTaXpWOFhRR2p1Cm5OOHlDZC9TL0dyMWJlODlDWEdOMXJRVU9qdEtOd2REMk5NUDAydXArRnJJalI1MW5VM2x6T0pPb1E5V2VSR0oKRG1IZ0NYWGNUT1VRd3hxeUpPbkc0dkxqTVo5Y1pUbUN5b1M0UUFKUzllY213dnFCZDZ3d2UzM0xwOGRUZW1MbApBRlVpMFdrRzZVN241bE5Od0t4RmlteWx0VkpKV1lQZzZaRlJzTHQ2VXlUdVY3Qzc1eXdJZjJkN05ZaUM3VjJ2CjdLUmlObUZINmpYazhDU09YS3lueHZDaVVsMENBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGR2E5MzVZcTlhcFp0Q25oOXl6K2JSenU0SkNWTUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQWx3OTF5T2UyU1piTUZrZm1pQlhBSHdVUS8zRi9kdmtTbzJTL0wva2hQCmszbXlvaGpZWmxOVkx0WmtpS1FpSzFZMU1RWDE1V3pnR1BEcVpKcDZsbnA3eUsyMHJkV0o0UFBSUStRWHRUYWUKQldJOTNTWlRaZ1M4Sng4WnZNd1dxdXlnWm8ya3dvT1RZSTlFZEJiOTZTK0ppMFdHU1NSZUw1SHlYZmwxdm9SQwplSS9LVWRCM005RXZyR1JoejA0N3AxdEZwK3FaNTVZaGg1REVmME9LNmxaWW9TMzZDMmp4WjExUjAxNXliOHlVClFCSzNiK1lJTmZscUM2T2RpajA5Qys3T0tkQUhJZW1FVWdYMHJ1emJZRjJCVjVyZVNKd3h1bUJnT2JTSHZERVgKUVRHRE5CUzdVNWZpSVFEbTRpQS9kaDJ5YUg5czFYdmRjNHRPVzhpSVFMV3JIYkZ2Z29DVjhyWmVtNXp3TjE2bgpiVHJ1OVNEYXpiQXVVUW52N1NPSWNrUE94Y3EvcThMdlhGbHp0OVU1WVUwMGJNQ2FMejBOTXRFNjNnS3dlaFVjCmcwVUdoNlhnVDI4Y2gwRHVYNHg3MHQvZnNsV0M5TWd5V1hNenhoYXBWWVFGeHZKZm1BSXRTZFdOczEzT2xkeTcKTXBBTkUxbk9FQ0lMSjZqZmU2eCtCekk9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
 
         client_certificate_config {
             issue_client_certificate = false
+        }
+    }
+
+    master_authorized_networks_config {
+        gcp_public_cidrs_access_enabled      = true
+        private_endpoint_enforcement_enabled = false
+
+        cidr_blocks {
+            cidr_block   = "0.0.0.0/0"
+            display_name = "All Addresses"
         }
     }
 
@@ -169,7 +190,13 @@ resource "google_container_cluster" "model-serving" {
         boot_disk_kms_key           = null
         disk_size_gb                = 100
         disk_type                   = "pd-balanced"
-        effective_taints            = []
+        effective_taints            = [
+            {
+                effect = "NO_SCHEDULE"
+                key    = "nvidia.com/gpu"
+                value  = "present"
+            },
+        ]
         enable_confidential_storage = false
         image_type                  = "COS_CONTAINERD"
         labels                      = {
@@ -180,7 +207,7 @@ resource "google_container_cluster" "model-serving" {
         }
         local_ssd_count             = 0
         logging_variant             = "DEFAULT"
-        machine_type                = "n2d-standard-4"
+        machine_type                = "g2-standard-24"
         metadata                    = {
             "disable-legacy-endpoints" = "true"
         }
@@ -189,13 +216,24 @@ resource "google_container_cluster" "model-serving" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
+
+        guest_accelerator {
+            count              = 2
+            gpu_partition_size = null
+            type               = "nvidia-l4"
+        }
 
         kubelet_config {
             cpu_cfs_quota                          = false
@@ -218,19 +256,19 @@ resource "google_container_cluster" "model-serving" {
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-369aa165-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-d16e9974-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-5b0d7540-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-121bfe70-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-2b71cd93-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-6b71d1d0-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n2d-preempt-4-369aa165-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n2d-preempt-4-d16e9974-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-n2d-preempt-4-5b0d7540-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-24-spot-121bfe70-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-24-spot-2b71cd93-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-24-spot-6b71d1d0-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "n2d-preempt-4"
+        name                        = "g2-standard-24-spot"
         name_prefix                 = null
-        node_count                  = 1
+        node_count                  = 0
         node_locations              = [
             "us-west1-a",
             "us-west1-b",
@@ -240,22 +278,712 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 3
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 64
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-4a8db61c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-23925af4-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-a4b273f7-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-4a8db61c-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-nonsp-23925af4-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-a4b273f7-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west1-a",
+            "us-west1-b",
+            "us-west1-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.64.0.0/14"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-b18506b1-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-6d0597f8-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-b18506b1-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-6d0597f8-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west1-a",
+            "us-west1-b",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.64.0.0/14"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-27f2b303-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-8400dbb4-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-spot-27f2b303-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-spot-8400dbb4-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west1-a",
+            "us-west1-b",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.64.0.0/14"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-eb5f4070-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-0cc370bb-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-ce25ac72-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-spot-eb5f4070-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-spot-0cc370bb-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-spot-ce25ac72-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west1-a",
+            "us-west1-b",
+            "us-west1-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.64.0.0/14"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-87bc1dbb-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-ec897726-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-cecb8a34-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-24-nons-87bc1dbb-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-24-nons-ec897726-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-24-nons-cecb8a34-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-24-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west1-a",
+            "us-west1-b",
+            "us-west1-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.64.0.0/14"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-bc34fbf0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-dc5f17c9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-def91523-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-bc34fbf0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-dc5f17c9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-def91523-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n2d-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west1-a",
+            "us-west1-b",
+            "us-west1-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 3
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.64.0.0/14"
+            pod_range            = "gke-model-serving-pods-a44f9cd8"
         }
 
         node_config {
@@ -282,673 +1010,18 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-f382dc6b-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-00f81b34-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-f382dc6b-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-00f81b34-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west1-a",
-            "us-west1-b",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-93c70984-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-8def0502-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-48737071-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-preem-93c70984-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-preem-8def0502-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-preem-48737071-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west1-a",
-            "us-west1-b",
-            "us-west1-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
             preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-512b5437-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-ef3331c3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-327b1779-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-512b5437-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-nonpr-ef3331c3-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-327b1779-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west1-a",
-            "us-west1-b",
-            "us-west1-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
+            resource_labels             = {
                 "cluster"   = "model-serving"
                 "component" = "ai"
                 "feature"   = "external"
                 "team"      = "ai_eng"
             }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-3da700e1-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-nonpreempt-e54e9c7c-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-e1288b92-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-nonpreempt-3da700e1-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-nonpreempt-e54e9c7c-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-nonpreempt-e1288b92-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west1-a",
-            "us-west1-b",
-            "us-west1-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-c2f14f19-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-faa84031-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-c2f14f19-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-faa84031-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west1-a",
-            "us-west1-b",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-preempt-75dfb083-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-preempt-94e17c35-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-preempt-77845bb2-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-preempt-75dfb083-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-preempt-94e17c35-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-preempt-77845bb2-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west1-a",
-            "us-west1-b",
-            "us-west1-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.64.0.0/14"
-            pod_range            = "gke-model-serving-pods-7aa05e65"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
 
             kubelet_config {
                 cpu_cfs_quota                          = false
@@ -977,15 +1050,15 @@ resource "google_container_cluster" "model-serving" {
 
     node_pool_defaults {
         node_config_defaults {
-            insecure_kubelet_readonly_port_enabled = "FALSE"
+            insecure_kubelet_readonly_port_enabled = "TRUE"
             logging_variant                        = "DEFAULT"
         }
     }
 
     notification_config {
         pubsub {
-            enabled = false
-            topic   = null
+            enabled = true
+            topic   = "projects/voiceai-staging/topics/notifications-gke"
         }
     }
 
@@ -994,9 +1067,9 @@ resource "google_container_cluster" "model-serving" {
         enable_private_nodes        = false
         master_ipv4_cidr_block      = null
         peering_name                = null
-        private_endpoint            = "10.138.0.69"
+        private_endpoint            = "10.138.0.32"
         private_endpoint_subnetwork = null
-        public_endpoint             = "34.168.40.202"
+        public_endpoint             = "34.169.12.0"
 
         master_global_access_config {
             enabled = false
@@ -1013,7 +1086,7 @@ resource "google_container_cluster" "model-serving" {
 
     security_posture_config {
         mode               = "BASIC"
-        vulnerability_mode = "VULNERABILITY_MODE_UNSPECIFIED"
+        vulnerability_mode = "VULNERABILITY_BASIC"
     }
 
     service_external_ips_config {

--- a/cluster_us-west4.txt
+++ b/cluster_us-west4.txt
@@ -1,31 +1,34 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_cluster.model-serving:
-resource "google_container_cluster" "model-serving" {
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_cluster.cluster:
+resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr                        = "10.96.0.0/14"
     datapath_provider                        = null
     default_max_pods_per_node                = 110
-    deletion_protection                      = true
+    deletion_protection                      = false
     description                              = null
     effective_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     enable_autopilot                         = false
     enable_cilium_clusterwide_network_policy = false
     enable_intranode_visibility              = false
     enable_kubernetes_alpha                  = false
-    enable_l4_ilb_subsetting                 = false
+    enable_l4_ilb_subsetting                 = true
     enable_legacy_abac                       = false
     enable_multi_networking                  = false
     enable_shielded_nodes                    = true
     enable_tpu                               = false
-    endpoint                                 = "34.16.209.254"
+    endpoint                                 = "34.16.210.94"
     id                                       = "projects/voiceai-staging/locations/us-west4/clusters/model-serving"
     initial_node_count                       = 1
-    label_fingerprint                        = "b2b48c5e"
+    label_fingerprint                        = "47296234"
     location                                 = "us-west4"
     logging_service                          = "logging.googleapis.com/kubernetes"
     master_version                           = "1.28.15-gke.1020000"
-    min_master_version                       = "1.28.15-gke.1020000"
+    min_master_version                       = null
     monitoring_service                       = "monitoring.googleapis.com/kubernetes"
     name                                     = "model-serving"
     network                                  = "projects/voiceai-staging/global/networks/default"
@@ -40,14 +43,20 @@ resource "google_container_cluster" "model-serving" {
     project                                  = "voiceai-staging"
     remove_default_node_pool                 = true
     resource_labels                          = {
-        "cluster" = "model-serving"
+        "cluster"   = "model-serving"
+        "component" = "ai"
+        "feature"   = "external"
+        "team"      = "ai_eng"
     }
     self_link                                = "https://container.googleapis.com/v1/projects/voiceai-staging/locations/us-west4/clusters/model-serving"
     services_ipv4_cidr                       = "10.1.96.0/20"
     subnetwork                               = "projects/voiceai-staging/regions/us-west4/subnetworks/default"
     terraform_labels                         = {
         "cluster"                    = "model-serving"
+        "component"                  = "ai"
+        "feature"                    = "external"
         "goog-terraform-provisioned" = "true"
+        "team"                       = "ai_eng"
     }
     tpu_ipv4_cidr_block                      = null
 
@@ -57,6 +66,9 @@ resource "google_container_cluster" "model-serving" {
         }
         gcs_fuse_csi_driver_config {
             enabled = true
+        }
+        horizontal_pod_autoscaling {
+            disabled = true
         }
         http_load_balancing {
             disabled = false
@@ -80,7 +92,7 @@ resource "google_container_cluster" "model-serving" {
     control_plane_endpoints_config {
         dns_endpoint_config {
             allow_external_traffic = false
-            endpoint               = "gke-76fa98db61294006b60b5ca32ad2544e8116-397406432431.us-west4.gke.goog"
+            endpoint               = "gke-e6e7f8387726402e9c4bf856a0da50c43c46-397406432431.us-west4.gke.goog"
         }
     }
 
@@ -111,9 +123,9 @@ resource "google_container_cluster" "model-serving" {
 
     ip_allocation_policy {
         cluster_ipv4_cidr_block       = "10.96.0.0/14"
-        cluster_secondary_range_name  = "gke-model-serving-pods-76fa98db"
+        cluster_secondary_range_name  = "gke-model-serving-pods-e6e7f838"
         services_ipv4_cidr_block      = "10.1.96.0/20"
-        services_secondary_range_name = "gke-model-serving-services-76fa98db"
+        services_secondary_range_name = "gke-model-serving-services-e6e7f838"
         stack_type                    = "IPV4"
 
         pod_cidr_overprovision_config {
@@ -124,7 +136,6 @@ resource "google_container_cluster" "model-serving" {
     logging_config {
         enable_components = [
             "SYSTEM_COMPONENTS",
-            "WORKLOADS",
         ]
     }
 
@@ -138,10 +149,20 @@ resource "google_container_cluster" "model-serving" {
     master_auth {
         client_certificate     = null
         client_key             = (sensitive value)
-        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMVENDQXBXZ0F3SUJBZ0lSQUlrcHFTa1JTWW1GMWZLUklTNThXS0F3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa1lqazBNVGxoTVRndE56a3pNQzAwWmpSaUxXRmlPVEV0WXpZNVpXRTFOV0ZpWldKagpNQ0FYRFRJMU1ERXhNREE1TWpZME1Wb1lEekl3TlRVd01UQXpNVEF5TmpReFdqQXZNUzB3S3dZRFZRUURFeVJpCk9UUXhPV0V4T0MwM09UTXdMVFJtTkdJdFlXSTVNUzFqTmpsbFlUVTFZV0psWW1Nd2dnR2lNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCandBd2dnR0tBb0lCZ1FESzdhTXkwY2phY01lQjdmUDg3UmVwTEVja1lxdFdibTZTMUc4KworVURyQTluelE2R3hVZUhETHZ0bENHL2o2bzBrRG5lOFovckFwL3ZlS0FaS1dXbzJVeHhJU1VzQ3I2V1UxMDFiCjJYdkxWVHlCRUdOU3VjeHUyUlFIbTlJTTdoSDI1WU9McWlYWkpNdXQrTEZ5VTcxS055L3lqSHVOYjJ5VGk4Wi8KMDJlSUNnWGFiWTQ4TEZvOTZ0enRhVjg2RTM1NWhxU3loYVd3T1FUci96MXFCM1N1WmhJWENuQUFoY0l3a1B0Mwp2aEJtd3haT2E5ZnNWbGt2MUpHeGE2Q2lUc0lhMlpEbXZMWDVXa1daSExTelREdnV1bHM0UlE1QUJWQUUzblNUClRmSko1T09Sb3J1VGFrMlY5U09LZWpxQTNBeFFUb1d1TU9GSFpsLzMzaGtuYkVKWDZIR21DUmgyaE5MVDdnYWgKaks2VThvdmRsT3lkTlNnV1FpNTJIM0VLQVNsTCt4RXFKRWZDSjdpMlRKTmNrYzIwMW8wVE1ac0JtOWpuVGJMTQpnMTgzdmI4THFvQWR5am9Uc255bFBRK08veDVsMG1WMm9zZGY0cjRRRVZ6bDBROCtCTFFTMjNWV2VSUFVCSzJUCllGbzg3bVEwT3JJY1hZWDBnMkVZM0x6ZG1wc0NBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdJRU1BOEcKQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGUDhkeHBiWlgzRmVtZHIvZ1dZWXF1RUQ0UXl2TUEwRwpDU3FHU0liM0RRRUJDd1VBQTRJQmdRQVo5ZmpjS3pHTUcxNU1LZE1ZUjdGSVloUFdScGtlSWpOcXpJbFBvQUxLCmlxNy9zaDA2Ynd1bUprY1c5dnZsRnBnUjB1Sm85NVRuVWFTdzR1VFNBR1Zwd0FSYXl0Y2ZIazBJYXFFTWlmTXIKL1Q3UGMybDFrVjgxc3VkWTNOSFRTZ0xhYkUyVFFuK0FUanBmOTRjZnBBOXpqU0lGREM5MW9tQUUza2orV0V6ZQpCT3V4SUg2MVdOVzFDQ3B5cTVTVWs2ZUVaaTVJMU9lMGdzdmtVdDNWTzlYQzZEaUs1VWZNcjQ4N2Y1T0w0Tis2CjBlWVNydExIVUs2R0FzUkN2UThJQmRWcE5rdm5Rckk1MFl1WWU3VTY1RDZEWVhGc0Q4NHVOTmd4cCtWbitnS0MKZXJRKzhESU15UVZhYjFoU0o4QURlU0xxNmE0bkY1NlozUjFuOU9nVHVueVo1MkVrVzdOY2NUMHM3VERWQTgzbgpuazREM3ZtejdYWGFYZWd0T0pJaDJsYi9lYmhWTHlpV0JMd2gwTDdrZ3ROT3gvaUxjUFBOeFVmODRqTmFXL0tZCm5IZjBzUHQybmNLa3R3bC9tMmtYYlRIUmRGOVhQTE1sVUxBVDM5RW5GUGxLNk03amZqeFpLdE1DOWdiaEFzWjYKb2QvWURPNEk1ekxKWTNVZGp6ZHhoMW89Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+        cluster_ca_certificate = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVMRENDQXBTZ0F3SUJBZ0lRVTZFOGR0SGY4RFhJemNRZzE5NUdnREFOQmdrcWhraUc5dzBCQVFzRkFEQXYKTVMwd0t3WURWUVFERXlRM1pUSXpOek5pWlMwM05HUXhMVFF3WVdFdE9URm1NQzB3TkdNNFltSTNPV1poWkdJdwpJQmNOTWpVd01UQTRNVGN5TXpRMldoZ1BNakExTlRBeE1ERXhPREl6TkRaYU1DOHhMVEFyQmdOVkJBTVRKRGRsCk1qTTNNMkpsTFRjMFpERXROREJoWVMwNU1XWXdMVEEwWXpoaVlqYzVabUZrWWpDQ0FhSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0dQQURDQ0FZb0NnZ0dCQUwvSlorTEQvL2ZWN0VhWC9BMldxV2JIUjVSeVpJcnBHQTErK1UydwoyalhVM3RjVUhoc0ZmWVhtOW43SVFMem1IeHNmSFpYSG1wenB2S0hEOWlHYXpVWHZkQ1dVRzd4SDRBeEhUMVFkCkllOVBkV0xCK29SQ25hWmlINmFYVkhZZ3dWd2dwVGt2a2R3OFZ4WFJ0UnBWUVhhY0FSQkxHdGFJbnJlZ1dwL0kKTHRIUmZNSVNrSFBTZWx4emVNekZnejl5aEFOTnNDWDFwN3BIRER4djJQTUNsMnJpejNYN2ZTYmYvdjFOQ2RXYQpsaFdhVnc5VHNHTEx1UElqbU5Sd0F4bmpLOW5BUG1tbmtmQmJVd1pCM1dZRjBwSTJTa1VVMFZ2SFM5ZE5vSTBoCnZ3TkloWERzNkhBV2xnckR5eFlCWmRHRXBhY0lXWUkwNzFvek1wT09jamlXTWd1S1cvYUo1RHNkVEdnWlhzSWMKWHNBZWV1V0pERDJDSVJRa1V3UFdjaEIvbTNRU0ppWXdqTU5uNENtYkxYRHh4anlrREVkcW9MRWUycENqeit3Tgpid1ZRQUFOVno1SzRaL3llMWd1RmkvQjdOVHFheUVQUEYxSmtkTEl3RitUckxJaXdXczduNzdyNFRXRi9OakNiClpyeWpFb2NrSG0rRlQvbkZtTUc2bG5mT2RRSURBUUFCbzBJd1FEQU9CZ05WSFE4QkFmOEVCQU1DQWdRd0R3WUQKVlIwVEFRSC9CQVV3QXdFQi96QWRCZ05WSFE0RUZnUVVBTDdZanM4NHRROHlwVFQ5WDFrTWx0Mng3dnd3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dHQkFMRGZCcVRWWW5uUVdXTkx5MzNyRCtVZVBQdEVmRVYxU1praDFPZnJITXFnCnAxV1FDcDdxNkcvQWM3NlU1RzhwbU42UlEyWGhFNjJmdWFjUFdEZDZtZmlXSk9Ub1hnUWI4YjhoVk1MNjdHc0kKeGYzZFJZSmxzT1VVMzlPWUxmcmxmVEV4S3J6WXh6aWJOckgzT1hXWERnb25BWTR1Y1RzR3Zkc1hLS0JEZHlsYQpZYVpDamViMnlZdEJ4aVRuWExIRGZNeDY1SGJYL3VjeEJGVG5xZTVlajBlcTVtZys3R1U1L0N0U1MyYkJTTXA0ClhJbnlkYkZaeFBhUzlKdnlFZDZRMThlUzB6a25yVFNXMU1jQWJYdC9Oajc5K1JjM1ducUZRQjh0cGMzUWU0SHAKaXpqTGRQdzNGOTJQUXBGWWxQQm9uME1mTFlUaEdzbHVaWXJ5NVlwdGNWb2d2blRWc1Q4UmF5blMyOExDcEFYUwpiazgrMWFYTElSQTAzYkcwZkJzaEVqOVhiUFVRa0RqTGJ5TXBxY2Q3eUw2QmpjVlRIbWRIR2RRSDBmY3ZHWjU1CklqWjIxNjFzOWFFQ20yYUxpYkNva20yalQ5S3c0OGpqdVN1QmN6RHc0MHk3WDZlZldhenlVeVlWWkVhaE5LeWcKNXV0ak9YZzg2ZmR0M3crZGVqaHIvZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
 
         client_certificate_config {
             issue_client_certificate = false
+        }
+    }
+
+    master_authorized_networks_config {
+        gcp_public_cidrs_access_enabled      = true
+        private_endpoint_enforcement_enabled = false
+
+        cidr_blocks {
+            cidr_block   = "0.0.0.0/0"
+            display_name = "All Addresses"
         }
     }
 
@@ -186,7 +207,7 @@ resource "google_container_cluster" "model-serving" {
         }
         local_ssd_count             = 0
         logging_variant             = "DEFAULT"
-        machine_type                = "g2-standard-4"
+        machine_type                = "n1-standard-4"
         metadata                    = {
             "disable-legacy-endpoints" = "true"
         }
@@ -196,17 +217,22 @@ resource "google_container_cluster" "model-serving" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
         guest_accelerator {
             count              = 1
             gpu_partition_size = null
-            type               = "nvidia-l4"
+            type               = "nvidia-tesla-t4"
         }
 
         kubelet_config {
@@ -230,123 +256,15 @@ resource "google_container_cluster" "model-serving" {
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f223353e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-00a0f675-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-edeebb60-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-ac8c39d9-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f223353e-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-00a0f675-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-spot-edeebb60-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-spot-ac8c39d9-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "g2-standard-4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west4-a",
-            "us-west4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-89f31c23-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-3c07ec92-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-89f31c23-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-3c07ec92-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-preempt"
+        name                        = "n1-standard-4-spot"
         name_prefix                 = null
         node_count                  = 0
         node_locations              = [
@@ -357,454 +275,22 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 1
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 100
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "n1-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-tesla-t4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-43c31f96-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-4fccb501-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-preem-43c31f96-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-preem-4fccb501-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-standard-4-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west4-a",
-            "us-west4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-4"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 1
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-preempt-3c2799dd-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-preempt-f38bbb59-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-preempt-3c2799dd-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-preempt-f38bbb59-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-preempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west4-a",
-            "us-west4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "ANY"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = true
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-92016ba2-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-9078fb6c-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-nonpreempt-92016ba2-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-nonpreempt-9078fb6c-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "g2-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west4-a",
-            "us-west4-c",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
-        }
-
-        node_config {
-            boot_disk_kms_key           = null
-            disk_size_gb                = 100
-            disk_type                   = "pd-balanced"
-            effective_taints            = [
-                {
-                    effect = "NO_SCHEDULE"
-                    key    = "nvidia.com/gpu"
-                    value  = "present"
-                },
-            ]
-            enable_confidential_storage = false
-            image_type                  = "COS_CONTAINERD"
-            labels                      = {
-                "cluster"   = "model-serving"
-                "component" = "ai"
-                "feature"   = "external"
-                "team"      = "ai_eng"
-            }
-            local_ssd_count             = 0
-            logging_variant             = "DEFAULT"
-            machine_type                = "g2-standard-24"
-            metadata                    = {
-                "disable-legacy-endpoints" = "true"
-            }
-            min_cpu_platform            = null
-            node_group                  = null
-            oauth_scopes                = [
-                "https://www.googleapis.com/auth/cloud-platform",
-            ]
-            preemptible                 = false
-            resource_labels             = {}
-            resource_manager_tags       = {}
-            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
-            storage_pools               = []
-            tags                        = []
-
-            guest_accelerator {
-                count              = 2
-                gpu_partition_size = null
-                type               = "nvidia-l4"
-            }
-
-            kubelet_config {
-                cpu_cfs_quota                          = false
-                cpu_cfs_quota_period                   = null
-                cpu_manager_policy                     = null
-                insecure_kubelet_readonly_port_enabled = "TRUE"
-                pod_pids_limit                         = 0
-            }
-
-            shielded_instance_config {
-                enable_integrity_monitoring = true
-                enable_secure_boot          = false
-            }
-
-            workload_metadata_config {
-                mode = "GKE_METADATA"
-            }
-        }
-
-        upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
-            strategy        = "SURGE"
-        }
-    }
-    node_pool {
-        initial_node_count          = 1
-        instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-0bd09087-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-1a789aa8-grp",
-        ]
-        managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-0bd09087-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-1a789aa8-grp",
-        ]
-        max_pods_per_node           = 110
-        name                        = "n1-standard-4-t4-nonpreempt"
-        name_prefix                 = null
-        node_count                  = 0
-        node_locations              = [
-            "us-west4-a",
-            "us-west4-b",
-        ]
-        version                     = "1.28.15-gke.1020000"
-
-        autoscaling {
-            location_policy      = "BALANCED"
-            max_node_count       = 1
-            min_node_count       = 0
-            total_max_node_count = 0
-            total_min_node_count = 0
-        }
-
-        management {
-            auto_repair  = true
-            auto_upgrade = false
-        }
-
-        network_config {
-            create_pod_range     = false
-            enable_private_nodes = false
-            pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
         }
 
         node_config {
@@ -838,7 +324,125 @@ resource "google_container_cluster" "model-serving" {
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
             preemptible                 = false
-            resource_labels             = {}
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-tesla-t4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-ae48a3f1-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-a3e0d649-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-ae48a3f1-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-a3e0d649-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n1-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west4-a",
+            "us-west4-b",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 100
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.96.0.0/14"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "n1-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
             spot                        = false
@@ -870,27 +474,479 @@ resource "google_container_cluster" "model-serving" {
         }
 
         upgrade_settings {
-            max_surge       = 1
-            max_unavailable = 0
+            max_surge       = 0
+            max_unavailable = 1
             strategy        = "SURGE"
         }
     }
     node_pool {
         initial_node_count          = 1
         instance_group_urls         = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-b7a81cf7-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-805d4dcf-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-b6e8a513-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-e9b2eec8-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-1ae28194-grp",
         ]
         managed_instance_group_urls = [
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n2d-preempt-4-b7a81cf7-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n2d-preempt-4-805d4dcf-grp",
-            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-n2d-preempt-4-b6e8a513-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-24-spot-e9b2eec8-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-24-spot-1ae28194-grp",
         ]
         max_pods_per_node           = 110
-        name                        = "n2d-preempt-4"
+        name                        = "g2-standard-24-spot"
         name_prefix                 = null
-        node_count                  = 1
+        node_count                  = 0
+        node_locations              = [
+            "us-west4-a",
+            "us-west4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.96.0.0/14"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-6ec9b6fd-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-b91a1530-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-6ec9b6fd-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-b91a1530-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west4-a",
+            "us-west4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.96.0.0/14"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-d9c733ad-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-822c5e62-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-spot-d9c733ad-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-spot-822c5e62-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west4-a",
+            "us-west4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.96.0.0/14"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-4"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = true
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 1
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-64ceeec9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-74063781-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-24-nons-64ceeec9-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-24-nons-74063781-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "g2-standard-24-nonspot"
+        name_prefix                 = null
+        node_count                  = 0
+        node_locations              = [
+            "us-west4-a",
+            "us-west4-c",
+        ]
+        version                     = "1.28.15-gke.1020000"
+
+        autoscaling {
+            location_policy      = "ANY"
+            max_node_count       = 0
+            min_node_count       = 0
+            total_max_node_count = 64
+            total_min_node_count = 0
+        }
+
+        management {
+            auto_repair  = true
+            auto_upgrade = true
+        }
+
+        network_config {
+            create_pod_range     = false
+            enable_private_nodes = false
+            pod_ipv4_cidr_block  = "10.96.0.0/14"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
+        }
+
+        node_config {
+            boot_disk_kms_key           = null
+            disk_size_gb                = 100
+            disk_type                   = "pd-balanced"
+            effective_taints            = [
+                {
+                    effect = "NO_SCHEDULE"
+                    key    = "nvidia.com/gpu"
+                    value  = "present"
+                },
+            ]
+            enable_confidential_storage = false
+            image_type                  = "COS_CONTAINERD"
+            labels                      = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            local_ssd_count             = 0
+            logging_variant             = "DEFAULT"
+            machine_type                = "g2-standard-24"
+            metadata                    = {
+                "disable-legacy-endpoints" = "true"
+            }
+            min_cpu_platform            = null
+            node_group                  = null
+            oauth_scopes                = [
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
+            resource_manager_tags       = {}
+            service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
+            spot                        = false
+            storage_pools               = []
+            tags                        = []
+
+            guest_accelerator {
+                count              = 2
+                gpu_partition_size = null
+                type               = "nvidia-l4"
+            }
+
+            kubelet_config {
+                cpu_cfs_quota                          = false
+                cpu_cfs_quota_period                   = null
+                cpu_manager_policy                     = null
+                insecure_kubelet_readonly_port_enabled = "TRUE"
+                pod_pids_limit                         = 0
+            }
+
+            shielded_instance_config {
+                enable_integrity_monitoring = true
+                enable_secure_boot          = false
+            }
+
+            workload_metadata_config {
+                mode = "GKE_METADATA"
+            }
+        }
+
+        upgrade_settings {
+            max_surge       = 0
+            max_unavailable = 1
+            strategy        = "SURGE"
+        }
+    }
+    node_pool {
+        initial_node_count          = 1
+        instance_group_urls         = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-4d5067f0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-d08738cb-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-597c51cb-grp",
+        ]
+        managed_instance_group_urls = [
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-4d5067f0-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-d08738cb-grp",
+            "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-597c51cb-grp",
+        ]
+        max_pods_per_node           = 110
+        name                        = "n2d-standard-4-spot"
+        name_prefix                 = null
+        node_count                  = 0
         node_locations              = [
             "us-west4-a",
             "us-west4-b",
@@ -900,22 +956,22 @@ resource "google_container_cluster" "model-serving" {
 
         autoscaling {
             location_policy      = "ANY"
-            max_node_count       = 3
+            max_node_count       = 0
             min_node_count       = 0
-            total_max_node_count = 0
+            total_max_node_count = 3
             total_min_node_count = 0
         }
 
         management {
             auto_repair  = true
-            auto_upgrade = false
+            auto_upgrade = true
         }
 
         network_config {
             create_pod_range     = false
             enable_private_nodes = false
             pod_ipv4_cidr_block  = "10.96.0.0/14"
-            pod_range            = "gke-model-serving-pods-76fa98db"
+            pod_range            = "gke-model-serving-pods-e6e7f838"
         }
 
         node_config {
@@ -942,11 +998,16 @@ resource "google_container_cluster" "model-serving" {
             oauth_scopes                = [
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
-            preemptible                 = true
-            resource_labels             = {}
+            preemptible                 = false
+            resource_labels             = {
+                "cluster"   = "model-serving"
+                "component" = "ai"
+                "feature"   = "external"
+                "team"      = "ai_eng"
+            }
             resource_manager_tags       = {}
             service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-            spot                        = false
+            spot                        = true
             storage_pools               = []
             tags                        = []
 
@@ -977,15 +1038,15 @@ resource "google_container_cluster" "model-serving" {
 
     node_pool_defaults {
         node_config_defaults {
-            insecure_kubelet_readonly_port_enabled = "FALSE"
+            insecure_kubelet_readonly_port_enabled = "TRUE"
             logging_variant                        = "DEFAULT"
         }
     }
 
     notification_config {
         pubsub {
-            enabled = false
-            topic   = null
+            enabled = true
+            topic   = "projects/voiceai-staging/topics/notifications-gke"
         }
     }
 
@@ -994,9 +1055,9 @@ resource "google_container_cluster" "model-serving" {
         enable_private_nodes        = false
         master_ipv4_cidr_block      = null
         peering_name                = null
-        private_endpoint            = "10.182.0.13"
+        private_endpoint            = "10.182.0.85"
         private_endpoint_subnetwork = null
-        public_endpoint             = "34.16.209.254"
+        public_endpoint             = "34.16.210.94"
 
         master_global_access_config {
             enabled = false
@@ -1013,7 +1074,7 @@ resource "google_container_cluster" "model-serving" {
 
     security_posture_config {
         mode               = "BASIC"
-        vulnerability_mode = "VULNERABILITY_MODE_UNSPECIFIED"
+        vulnerability_mode = "VULNERABILITY_BASIC"
     }
 
     service_external_ips_config {

--- a/node_pool_us-central1_c3-highcpu-22-nonpreempt.txt
+++ b/node_pool_us-central1_c3-highcpu-22-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["c3-highcpu-22-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["c3-highcpu-22-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/c3-highcpu-22-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/c3-highcpu-22-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-d12e0481-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-3fd956e9-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-18924f65-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-1471850c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-09db72b6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-216d47c6-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-d12e0481-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-3fd956e9-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-18924f65-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-1471850c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-09db72b6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-216d47c6-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "c3-highcpu-22-nonpreempt"
+    name                        = "c3-highcpu-22-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,16 +27,16 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 160
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -71,7 +71,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_c3-highcpu-22-preempt.txt
+++ b/node_pool_us-central1_c3-highcpu-22-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["c3-highcpu-22-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["c3-highcpu-22-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/c3-highcpu-22-preempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/c3-highcpu-22-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-c2d97c2f-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-22583924-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-53f6ff7e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-390784a3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-ba1fe6e3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-a4060891-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-preem-c2d97c2f-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-preem-22583924-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-preem-53f6ff7e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-c3-highcpu-22-spot-390784a3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-c3-highcpu-22-spot-ba1fe6e3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-c3-highcpu-22-spot-a4060891-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "c3-highcpu-22-preempt"
+    name                        = "c3-highcpu-22-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,15 +28,15 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 160
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_g2-nonpreempt.txt
+++ b/node_pool_us-central1_g2-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["g2-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["g2-standard-24-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-standard-24-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-bf578ba6-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-nonpreempt-e94984fe-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-5d24ccbe-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-9e2024bf-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-0df2cd0b-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-95638d8d-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-nonpreempt-bf578ba6-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-nonpreempt-e94984fe-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-nonpreempt-5d24ccbe-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-24-nons-9e2024bf-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-24-nons-0df2cd0b-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-24-nons-95638d8d-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-nonpreempt"
+    name                        = "g2-standard-24-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,16 +27,16 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_g2-preempt.txt
+++ b/node_pool_us-central1_g2-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["g2-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["g2-standard-24-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-preempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-standard-24-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-preempt-8858e2ea-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-preempt-8f88fc3f-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-preempt-02eab0ce-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-8a532a5a-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-f3b81609-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-6a5c2942-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-preempt-8858e2ea-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-preempt-8f88fc3f-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-preempt-02eab0ce-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-24-spot-8a532a5a-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-24-spot-f3b81609-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-24-spot-6a5c2942-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-preempt"
+    name                        = "g2-standard-24-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,15 +28,15 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -76,11 +76,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_g2-standard-4-nonpreempt.txt
+++ b/node_pool_us-central1_g2-standard-4-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["g2-standard-4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["g2-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-standard-4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-ce0b5cb3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-015517ee-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f6847575-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-c879b327-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-5522f085-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-e6d32d8b-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-ce0b5cb3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-nonpr-015517ee-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f6847575-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-c879b327-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-nonsp-5522f085-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-e6d32d8b-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-nonpreempt"
+    name                        = "g2-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,16 +27,16 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_g2-standard-4-preempt.txt
+++ b/node_pool_us-central1_g2-standard-4-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["g2-standard-4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["g2-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-standard-4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/g2-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-1d3df81a-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-c2ba4109-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-952c9f5c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-d14c2118-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-0c473c45-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-48b81433-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-preem-1d3df81a-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-preem-c2ba4109-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-preem-952c9f5c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-g2-standard-4-spot-d14c2118-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-g2-standard-4-spot-0c473c45-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-g2-standard-4-spot-48b81433-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-preempt"
+    name                        = "g2-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,16 +27,16 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -77,10 +77,15 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_n1-standard-4-t4-nonpreempt.txt
+++ b/node_pool_us-central1_n1-standard-4-t4-nonpreempt.txt
@@ -1,23 +1,23 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["n1-standard-4-t4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["n1-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/n1-standard-4-t4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/n1-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-f115ac3a-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-8bf85748-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-7e29bc63-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-0aa27abf-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-98317204-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-20dcbfdd-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-0228064d-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-4bc24623-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-f115ac3a-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-8bf85748-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-no-7e29bc63-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-t4-no-0aa27abf-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-98317204-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-20dcbfdd-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-nonsp-0228064d-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-nonsp-4bc24623-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-nonpreempt"
+    name                        = "n1-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -30,16 +30,16 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -80,7 +80,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -118,8 +123,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_n1-standard-4-t4-preempt.txt
+++ b/node_pool_us-central1_n1-standard-4-t4-preempt.txt
@@ -1,23 +1,23 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["n1-standard-4-t4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["n1-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/n1-standard-4-t4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/n1-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-e9504ce3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-8eed27a0-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-3c3165b3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-5970bb86-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-94554001-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-c6fd1e0d-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-6634f995-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-ef34555b-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-e9504ce3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-8eed27a0-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-3c3165b3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-5970bb86-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n1-standard-4-spot-94554001-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n1-standard-4-spot-c6fd1e0d-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n1-standard-4-spot-6634f995-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n1-standard-4-spot-ef34555b-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-preempt"
+    name                        = "n1-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -31,15 +31,15 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -79,11 +79,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -118,8 +123,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-central1_n2d-preempt-4.txt
+++ b/node_pool_us-central1_n2d-preempt-4.txt
@@ -1,45 +1,42 @@
-# module.gcp.module.k8s.module.model-serving.module.us-central1.google_container_node_pool.pool["n2d-preempt-4"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-central1.google_container_node_pool.pool["n2d-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/n2d-preempt-4"
+    id                          = "projects/voiceai-staging/locations/us-central1/clusters/model-serving/nodePools/n2d-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-332a5f7b-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-e56aa049-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-58f1582e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroupManagers/gke-model-serving-n2d-preempt-4-dff58a6e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-b2180517-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-2dd248c9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-5c0ad56e-grp",
     ]
     location                    = "us-central1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n2d-preempt-4-332a5f7b-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n2d-preempt-4-e56aa049-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n2d-preempt-4-58f1582e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-f/instanceGroups/gke-model-serving-n2d-preempt-4-dff58a6e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-b2180517-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-2dd248c9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-central1-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-5c0ad56e-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n2d-preempt-4"
+    name                        = "n2d-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
         "us-central1-a",
         "us-central1-b",
         "us-central1-c",
-        "us-central1-f",
     ]
     project                     = "voiceai-staging"
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 3
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 3
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
@@ -73,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -100,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_c3-highcpu-22-nonpreempt.txt
+++ b/node_pool_us-east1_c3-highcpu-22-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["c3-highcpu-22-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["c3-highcpu-22-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/c3-highcpu-22-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/c3-highcpu-22-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-d4ab158e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-46b2c4d7-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-414045d6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-922a6185-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-b1e5105c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-6535846c-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-d4ab158e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-46b2c4d7-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-414045d6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-922a6185-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-b1e5105c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-6535846c-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "c3-highcpu-22-nonpreempt"
+    name                        = "c3-highcpu-22-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 160
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -71,7 +71,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_c3-highcpu-22-preempt.txt
+++ b/node_pool_us-east1_c3-highcpu-22-preempt.txt
@@ -1,23 +1,23 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["c3-highcpu-22-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["c3-highcpu-22-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/c3-highcpu-22-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/c3-highcpu-22-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-e5030560-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-2ef89e73-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-8c6c3a27-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-1393ca57-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-00bfb5d4-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-a153c129-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-preem-e5030560-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-preem-2ef89e73-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-preem-8c6c3a27-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-c3-highcpu-22-spot-1393ca57-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-c3-highcpu-22-spot-00bfb5d4-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-c3-highcpu-22-spot-a153c129-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "c3-highcpu-22-preempt"
+    name                        = "c3-highcpu-22-spot"
     name_prefix                 = null
-    node_count                  = 1
+    node_count                  = 0
     node_locations              = [
         "us-east1-b",
         "us-east1-c",
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 160
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_g2-nonpreempt.txt
+++ b/node_pool_us-east1_g2-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["g2-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["g2-standard-24-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-standard-24-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-nonpreempt-9f2f202e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-9b3677e8-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-nonpreempt-ff7daeb2-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-9b8eabe7-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-3b1d3916-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-55c8da63-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-nonpreempt-9f2f202e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-nonpreempt-9b3677e8-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-nonpreempt-ff7daeb2-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-24-nons-9b8eabe7-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-24-nons-3b1d3916-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-24-nons-55c8da63-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-nonpreempt"
+    name                        = "g2-standard-24-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_g2-preempt.txt
+++ b/node_pool_us-east1_g2-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["g2-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["g2-standard-24-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-standard-24-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-preempt-6b952a3a-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-preempt-4067d6ac-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-preempt-fa632cd6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-1628f2f5-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-fb1bbc63-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-082bbe7c-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-preempt-6b952a3a-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-preempt-4067d6ac-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-preempt-fa632cd6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-24-spot-1628f2f5-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-24-spot-fb1bbc63-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-24-spot-082bbe7c-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-preempt"
+    name                        = "g2-standard-24-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -76,11 +76,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_g2-standard-4-nonpreempt.txt
+++ b/node_pool_us-east1_g2-standard-4-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["g2-standard-4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["g2-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-standard-4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f9d6d7f4-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f9ee5ce9-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-3e9211fb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-f4b9a5c9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-30939671-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-6fdea85e-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f9d6d7f4-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f9ee5ce9-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-nonpr-3e9211fb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-nonsp-f4b9a5c9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-30939671-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-nonsp-6fdea85e-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-nonpreempt"
+    name                        = "g2-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_g2-standard-4-preempt.txt
+++ b/node_pool_us-east1_g2-standard-4-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["g2-standard-4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["g2-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-standard-4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/g2-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-b1f880f8-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-0414ec03-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-fb1b9053-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-3af6e709-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-5e7f0878-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-ca455897-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-preem-b1f880f8-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-preem-0414ec03-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-preem-fb1b9053-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-g2-standard-4-spot-3af6e709-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-g2-standard-4-spot-5e7f0878-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-g2-standard-4-spot-ca455897-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-preempt"
+    name                        = "g2-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -77,10 +77,15 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_n1-standard-4-t4-nonpreempt.txt
+++ b/node_pool_us-east1_n1-standard-4-t4-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["n1-standard-4-t4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["n1-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/n1-standard-4-t4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/n1-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-b33ac3c1-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-7cee3a94-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-6b0380f1-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-ecf07dba-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-no-b33ac3c1-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-t4-no-7cee3a94-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-nonsp-6b0380f1-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-nonsp-ecf07dba-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-nonpreempt"
+    name                        = "n1-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_n1-standard-4-t4-preempt.txt
+++ b/node_pool_us-east1_n1-standard-4-t4-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["n1-standard-4-t4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["n1-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/n1-standard-4-t4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/n1-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-236f3835-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-cea9f700-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-f6892212-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-ea3bd747-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-236f3835-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-cea9f700-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n1-standard-4-spot-f6892212-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n1-standard-4-spot-ea3bd747-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-preempt"
+    name                        = "n1-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -25,22 +25,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -73,11 +73,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east1_n2d-preempt-4.txt
+++ b/node_pool_us-east1_n2d-preempt-4.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east1.google_container_node_pool.pool["n2d-preempt-4"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east1.google_container_node_pool.pool["n2d-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/n2d-preempt-4"
+    id                          = "projects/voiceai-staging/locations/us-east1/clusters/model-serving/nodePools/n2d-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-300524f8-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-6bfbadc5-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n2d-preempt-4-541a0949-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-7ec35ccc-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-fbb66ae6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-f6a4e9d9-grp",
     ]
     location                    = "us-east1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-n2d-preempt-4-300524f8-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n2d-preempt-4-6bfbadc5-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n2d-preempt-4-541a0949-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-7ec35ccc-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-fbb66ae6-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east1-d/instanceGroups/gke-model-serving-n2d-standard-4-spot-f6a4e9d9-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n2d-preempt-4"
+    name                        = "n2d-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 3
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 3
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.28.0.0/14"
-        pod_range            = "gke-model-serving-pods-c9c5abcc"
+        pod_range            = "gke-model-serving-pods-b539372d"
     }
 
     node_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_c3-highcpu-22-nonpreempt.txt
+++ b/node_pool_us-east4_c3-highcpu-22-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["c3-highcpu-22-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["c3-highcpu-22-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/c3-highcpu-22-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/c3-highcpu-22-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-9c3f6a2b-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-ad2ac853-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonpr-8c66dcc3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-b6815637-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-9c7f99c5-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-nonsp-0c9c66d4-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-9c3f6a2b-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-ad2ac853-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonpr-8c66dcc3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-b6815637-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-9c7f99c5-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-nonsp-0c9c66d4-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "c3-highcpu-22-nonpreempt"
+    name                        = "c3-highcpu-22-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 160
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -71,7 +71,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_c3-highcpu-22-preempt.txt
+++ b/node_pool_us-east4_c3-highcpu-22-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["c3-highcpu-22-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["c3-highcpu-22-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/c3-highcpu-22-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/c3-highcpu-22-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-f1470694-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-4304da83-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-preem-3c766684-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-d7a28962-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-e0f28ec0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-c3-highcpu-22-spot-94803393-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-preem-f1470694-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-preem-4304da83-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-preem-3c766684-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-c3-highcpu-22-spot-d7a28962-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-c3-highcpu-22-spot-e0f28ec0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-c3-highcpu-22-spot-94803393-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "c3-highcpu-22-preempt"
+    name                        = "c3-highcpu-22-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 160
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_g2-nonpreempt.txt
+++ b/node_pool_us-east4_g2-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["g2-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["g2-standard-24-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-standard-24-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-308c993f-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-d0d0716c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-c9283ac0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-0deb3100-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-nonpreempt-308c993f-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-nonpreempt-d0d0716c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-24-nons-c9283ac0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-24-nons-0deb3100-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-nonpreempt"
+    name                        = "g2-standard-24-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_g2-preempt.txt
+++ b/node_pool_us-east4_g2-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["g2-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["g2-standard-24-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-standard-24-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-preempt-35daa318-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-preempt-4bf41f90-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-7521d143-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-c91bbc54-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-preempt-35daa318-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-preempt-4bf41f90-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-24-spot-7521d143-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-24-spot-c91bbc54-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-preempt"
+    name                        = "g2-standard-24-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -25,22 +25,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -73,11 +73,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_g2-standard-4-nonpreempt.txt
+++ b/node_pool_us-east4_g2-standard-4-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["g2-standard-4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["g2-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-standard-4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-20699753-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-9d3ebe0b-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-9d8a5407-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-575aa9f6-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-20699753-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-9d3ebe0b-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-9d8a5407-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-575aa9f6-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-nonpreempt"
+    name                        = "g2-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_g2-standard-4-preempt.txt
+++ b/node_pool_us-east4_g2-standard-4-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["g2-standard-4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["g2-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-standard-4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/g2-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-906c1492-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-821a68b3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-08f5365e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-72865fd4-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-preem-906c1492-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-preem-821a68b3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-g2-standard-4-spot-08f5365e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-g2-standard-4-spot-72865fd4-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-preempt"
+    name                        = "g2-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -74,10 +74,15 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_n1-standard-4-t4-nonpreempt.txt
+++ b/node_pool_us-east4_n1-standard-4-t4-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["n1-standard-4-t4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["n1-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/n1-standard-4-t4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/n1-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-32dac3c4-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-befe4694-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-e2fd8374-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-65993492-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-492647b4-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-dce47c20-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-32dac3c4-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-befe4694-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-t4-no-e2fd8374-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-65993492-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-492647b4-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-nonsp-dce47c20-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-nonpreempt"
+    name                        = "n1-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_n1-standard-4-t4-preempt.txt
+++ b/node_pool_us-east4_n1-standard-4-t4-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["n1-standard-4-t4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["n1-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/n1-standard-4-t4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/n1-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-a8b46c45-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-48a6a155-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-9b453bbc-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-71faab4e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-8da1c888-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-05ee716d-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-a8b46c45-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-48a6a155-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-9b453bbc-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n1-standard-4-spot-71faab4e-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n1-standard-4-spot-8da1c888-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n1-standard-4-spot-05ee716d-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-preempt"
+    name                        = "n1-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -76,11 +76,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-east4_n2d-preempt-4.txt
+++ b/node_pool_us-east4_n2d-preempt-4.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-east4.google_container_node_pool.pool["n2d-preempt-4"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-east4.google_container_node_pool.pool["n2d-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/n2d-preempt-4"
+    id                          = "projects/voiceai-staging/locations/us-east4/clusters/model-serving/nodePools/n2d-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-5b8d6051-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-f502307c-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-8568ee9c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-6399d1c2-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-c0ef80a3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-93b09ad6-grp",
     ]
     location                    = "us-east4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n2d-preempt-4-5b8d6051-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n2d-preempt-4-f502307c-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n2d-preempt-4-8568ee9c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-6399d1c2-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-c0ef80a3-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-east4-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-93b09ad6-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n2d-preempt-4"
+    name                        = "n2d-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 3
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 3
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.44.0.0/14"
-        pod_range            = "gke-model-serving-pods-4da5d9c4"
+        pod_range            = "gke-model-serving-pods-f79ef29f"
     }
 
     node_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_g2-nonpreempt.txt
+++ b/node_pool_us-west1_g2-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["g2-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["g2-standard-24-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-standard-24-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-3da700e1-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-nonpreempt-e54e9c7c-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-e1288b92-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-87bc1dbb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-ec897726-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-cecb8a34-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-nonpreempt-3da700e1-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-nonpreempt-e54e9c7c-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-nonpreempt-e1288b92-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-24-nons-87bc1dbb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-24-nons-ec897726-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-24-nons-cecb8a34-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-nonpreempt"
+    name                        = "g2-standard-24-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_g2-preempt.txt
+++ b/node_pool_us-west1_g2-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["g2-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["g2-standard-24-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-preempt"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-standard-24-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-preempt-75dfb083-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-preempt-94e17c35-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-preempt-77845bb2-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-121bfe70-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-2b71cd93-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-6b71d1d0-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-preempt-75dfb083-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-preempt-94e17c35-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-preempt-77845bb2-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-24-spot-121bfe70-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-24-spot-2b71cd93-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-24-spot-6b71d1d0-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-preempt"
+    name                        = "g2-standard-24-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -76,11 +76,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_g2-standard-4-nonpreempt.txt
+++ b/node_pool_us-west1_g2-standard-4-nonpreempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["g2-standard-4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["g2-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-standard-4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-512b5437-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-ef3331c3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-327b1779-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-4a8db61c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-23925af4-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-a4b273f7-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-512b5437-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-nonpr-ef3331c3-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-327b1779-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-4a8db61c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-nonsp-23925af4-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-a4b273f7-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-nonpreempt"
+    name                        = "g2-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -77,7 +77,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_g2-standard-4-preempt.txt
+++ b/node_pool_us-west1_g2-standard-4-preempt.txt
@@ -1,21 +1,21 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["g2-standard-4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["g2-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-standard-4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/g2-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-93c70984-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-8def0502-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-48737071-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-eb5f4070-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-0cc370bb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-ce25ac72-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-preem-93c70984-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-preem-8def0502-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-preem-48737071-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-g2-standard-4-spot-eb5f4070-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-g2-standard-4-spot-0cc370bb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-g2-standard-4-spot-ce25ac72-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-preempt"
+    name                        = "g2-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -27,23 +27,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -77,10 +77,15 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -115,8 +120,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_n1-standard-4-t4-nonpreempt.txt
+++ b/node_pool_us-west1_n1-standard-4-t4-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["n1-standard-4-t4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["n1-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/n1-standard-4-t4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/n1-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-c2f14f19-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-faa84031-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-b18506b1-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-6d0597f8-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-c2f14f19-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-faa84031-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-b18506b1-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-6d0597f8-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-nonpreempt"
+    name                        = "n1-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_n1-standard-4-t4-preempt.txt
+++ b/node_pool_us-west1_n1-standard-4-t4-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["n1-standard-4-t4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["n1-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/n1-standard-4-t4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/n1-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-f382dc6b-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-00f81b34-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-27f2b303-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-8400dbb4-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-f382dc6b-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-00f81b34-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n1-standard-4-spot-27f2b303-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n1-standard-4-spot-8400dbb4-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-preempt"
+    name                        = "n1-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -25,22 +25,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -73,11 +73,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west1_n2d-preempt-4.txt
+++ b/node_pool_us-west1_n2d-preempt-4.txt
@@ -1,23 +1,23 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west1.google_container_node_pool.pool["n2d-preempt-4"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west1.google_container_node_pool.pool["n2d-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/n2d-preempt-4"
+    id                          = "projects/voiceai-staging/locations/us-west1/clusters/model-serving/nodePools/n2d-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-369aa165-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-d16e9974-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-5b0d7540-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-bc34fbf0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-dc5f17c9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-def91523-grp",
     ]
     location                    = "us-west1"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n2d-preempt-4-369aa165-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n2d-preempt-4-d16e9974-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-n2d-preempt-4-5b0d7540-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-bc34fbf0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-dc5f17c9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west1-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-def91523-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n2d-preempt-4"
+    name                        = "n2d-standard-4-spot"
     name_prefix                 = null
-    node_count                  = 1
+    node_count                  = 0
     node_locations              = [
         "us-west1-a",
         "us-west1-b",
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 3
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 3
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.64.0.0/14"
-        pod_range            = "gke-model-serving-pods-7aa05e65"
+        pod_range            = "gke-model-serving-pods-a44f9cd8"
     }
 
     node_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_g2-nonpreempt.txt
+++ b/node_pool_us-west4_g2-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["g2-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["g2-standard-24-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-standard-24-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-nonpreempt-92016ba2-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-nonpreempt-9078fb6c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-64ceeec9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-nons-74063781-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-nonpreempt-92016ba2-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-nonpreempt-9078fb6c-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-24-nons-64ceeec9-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-24-nons-74063781-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-nonpreempt"
+    name                        = "g2-standard-24-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_g2-preempt.txt
+++ b/node_pool_us-west4_g2-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["g2-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["g2-standard-24-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-preempt"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-standard-24-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-preempt-3c2799dd-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-preempt-f38bbb59-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-e9b2eec8-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-24-spot-1ae28194-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-preempt-3c2799dd-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-preempt-f38bbb59-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-24-spot-e9b2eec8-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-24-spot-1ae28194-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-preempt"
+    name                        = "g2-standard-24-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -25,22 +25,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -73,11 +73,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_g2-standard-4-nonpreempt.txt
+++ b/node_pool_us-west4_g2-standard-4-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["g2-standard-4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["g2-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-standard-4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-f223353e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonpr-00a0f675-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-6ec9b6fd-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-nonsp-b91a1530-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-nonpr-f223353e-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-nonpr-00a0f675-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-nonsp-6ec9b6fd-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-nonsp-b91a1530-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-nonpreempt"
+    name                        = "g2-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_g2-standard-4-preempt.txt
+++ b/node_pool_us-west4_g2-standard-4-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["g2-standard-4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["g2-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-standard-4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/g2-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-43c31f96-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-preem-4fccb501-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-d9c733ad-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-g2-standard-4-spot-822c5e62-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-preem-43c31f96-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-preem-4fccb501-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-g2-standard-4-spot-d9c733ad-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-g2-standard-4-spot-822c5e62-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "g2-standard-4-preempt"
+    name                        = "g2-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 64
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -74,10 +74,15 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_n1-standard-4-t4-nonpreempt.txt
+++ b/node_pool_us-west4_n1-standard-4-t4-nonpreempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["n1-standard-4-t4-nonpreempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["n1-standard-4-nonspot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/n1-standard-4-t4-nonpreempt"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/n1-standard-4-nonspot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-0bd09087-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-no-1a789aa8-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-ae48a3f1-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-nonsp-a3e0d649-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-no-0bd09087-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-no-1a789aa8-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-nonsp-ae48a3f1-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-nonsp-a3e0d649-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-nonpreempt"
+    name                        = "n1-standard-4-nonspot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -24,23 +24,23 @@ resource "google_container_node_pool" "pool" {
     version                     = "1.28.15-gke.1020000"
 
     autoscaling {
-        location_policy      = "BALANCED"
-        max_node_count       = 1
+        location_policy      = "ANY"
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -74,7 +74,12 @@ resource "google_container_node_pool" "pool" {
             "https://www.googleapis.com/auth/cloud-platform",
         ]
         preemptible                 = false
-        resource_labels             = {}
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
         spot                        = false
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_n1-standard-4-t4-preempt.txt
+++ b/node_pool_us-west4_n1-standard-4-t4-preempt.txt
@@ -1,19 +1,19 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["n1-standard-4-t4-preempt"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["n1-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/n1-standard-4-t4-preempt"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/n1-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-89f31c23-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-t4-pr-3c07ec92-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-edeebb60-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n1-standard-4-spot-ac8c39d9-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-89f31c23-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-t4-pr-3c07ec92-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n1-standard-4-spot-edeebb60-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n1-standard-4-spot-ac8c39d9-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n1-standard-4-t4-preempt"
+    name                        = "n1-standard-4-spot"
     name_prefix                 = null
     node_count                  = 0
     node_locations              = [
@@ -25,22 +25,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 1
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 100
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -73,11 +73,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -112,8 +117,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }

--- a/node_pool_us-west4_n2d-preempt-4.txt
+++ b/node_pool_us-west4_n2d-preempt-4.txt
@@ -1,23 +1,23 @@
-# module.gcp.module.k8s.module.model-serving.module.us-west4.google_container_node_pool.pool["n2d-preempt-4"]:
+# module.gcp.module.model-serving.module.gke-model-serving-us-west4.google_container_node_pool.pool["n2d-standard-4-spot"]:
 resource "google_container_node_pool" "pool" {
     cluster                     = "model-serving"
-    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/n2d-preempt-4"
+    id                          = "projects/voiceai-staging/locations/us-west4/clusters/model-serving/nodePools/n2d-standard-4-spot"
     initial_node_count          = 1
     instance_group_urls         = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n2d-preempt-4-b7a81cf7-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n2d-preempt-4-805d4dcf-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-n2d-preempt-4-b6e8a513-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-4d5067f0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-d08738cb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroupManagers/gke-model-serving-n2d-standard-4-spot-597c51cb-grp",
     ]
     location                    = "us-west4"
     managed_instance_group_urls = [
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n2d-preempt-4-b7a81cf7-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n2d-preempt-4-805d4dcf-grp",
-        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-n2d-preempt-4-b6e8a513-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-a/instanceGroups/gke-model-serving-n2d-standard-4-spot-4d5067f0-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-b/instanceGroups/gke-model-serving-n2d-standard-4-spot-d08738cb-grp",
+        "https://www.googleapis.com/compute/v1/projects/voiceai-staging/zones/us-west4-c/instanceGroups/gke-model-serving-n2d-standard-4-spot-597c51cb-grp",
     ]
     max_pods_per_node           = 110
-    name                        = "n2d-preempt-4"
+    name                        = "n2d-standard-4-spot"
     name_prefix                 = null
-    node_count                  = 1
+    node_count                  = 0
     node_locations              = [
         "us-west4-a",
         "us-west4-b",
@@ -28,22 +28,22 @@ resource "google_container_node_pool" "pool" {
 
     autoscaling {
         location_policy      = "ANY"
-        max_node_count       = 3
+        max_node_count       = 0
         min_node_count       = 0
-        total_max_node_count = 0
+        total_max_node_count = 3
         total_min_node_count = 0
     }
 
     management {
         auto_repair  = true
-        auto_upgrade = false
+        auto_upgrade = true
     }
 
     network_config {
         create_pod_range     = false
         enable_private_nodes = false
         pod_ipv4_cidr_block  = "10.96.0.0/14"
-        pod_range            = "gke-model-serving-pods-76fa98db"
+        pod_range            = "gke-model-serving-pods-e6e7f838"
     }
 
     node_config {
@@ -70,11 +70,16 @@ resource "google_container_node_pool" "pool" {
         oauth_scopes                = [
             "https://www.googleapis.com/auth/cloud-platform",
         ]
-        preemptible                 = true
-        resource_labels             = {}
+        preemptible                 = false
+        resource_labels             = {
+            "cluster"   = "model-serving"
+            "component" = "ai"
+            "feature"   = "external"
+            "team"      = "ai_eng"
+        }
         resource_manager_tags       = {}
         service_account             = "cluster-model-serving@voiceai-staging.iam.gserviceaccount.com"
-        spot                        = false
+        spot                        = true
         storage_pools               = []
         tags                        = []
 
@@ -97,8 +102,8 @@ resource "google_container_node_pool" "pool" {
     }
 
     upgrade_settings {
-        max_surge       = 1
-        max_unavailable = 0
+        max_surge       = 0
+        max_unavailable = 1
         strategy        = "SURGE"
     }
 }


### PR DESCRIPTION
The 'terraform show' outputs were captured at two points in time:
- terraform:staging running the master branch (the *before* files)
- terraform:staging running the refactored model serving app (the *after* files)

Due to node pool renaming, the output files sort the modules differently. Also, due to the differing in lengths of many module description, difftool is not able to accurately match up boundaries. A script was written to post-process the *after* terraform show outputs to pull out individual node pools and clusters into individual files. All other modules that are neither pools nor clusters remain in a general file. The modules within the *after* general file are sorted according to their respective order in the *before* file.  